### PR TITLE
Re-export bumpalo, since it is a public dependency anyways

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -126,7 +126,6 @@ dependencies = [
 name = "dodrio-counter"
 version = "0.1.0"
 dependencies = [
- "bumpalo 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "console_error_panic_hook 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "dodrio 0.1.0",
  "wasm-bindgen 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -138,7 +137,6 @@ dependencies = [
 name = "dodrio-hello-world"
 version = "0.1.0"
 dependencies = [
- "bumpalo 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "console_error_panic_hook 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "dodrio 0.1.0",
  "wasm-bindgen 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -150,7 +148,6 @@ dependencies = [
 name = "dodrio-input-form"
 version = "0.1.0"
 dependencies = [
- "bumpalo 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "console_error_panic_hook 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "dodrio 0.1.0",
  "wasm-bindgen 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/examples/counter/crate/Cargo.toml
+++ b/examples/counter/crate/Cargo.toml
@@ -10,7 +10,6 @@ crate-type = ["cdylib", "rlib"]
 [features]
 
 [dependencies]
-bumpalo = "1.0.2"
 dodrio = { path = "../../.." }
 wasm-bindgen = "0.2"
 console_error_panic_hook = "0.1.1"

--- a/examples/counter/crate/src/lib.rs
+++ b/examples/counter/crate/src/lib.rs
@@ -1,4 +1,4 @@
-use bumpalo::Bump;
+use dodrio::bumpalo::{self, Bump};
 use dodrio::{Attribute, Node, Render};
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsCast;

--- a/examples/hello-world/crate/Cargo.toml
+++ b/examples/hello-world/crate/Cargo.toml
@@ -10,7 +10,6 @@ crate-type = ["cdylib", "rlib"]
 [features]
 
 [dependencies]
-bumpalo = "1.0.2"
 dodrio = { path = "../../.." }
 wasm-bindgen = "0.2"
 console_error_panic_hook = "0.1.1"

--- a/examples/hello-world/crate/src/lib.rs
+++ b/examples/hello-world/crate/src/lib.rs
@@ -1,4 +1,4 @@
-use bumpalo::Bump;
+use dodrio::bumpalo::Bump;
 use dodrio::{Node, Render};
 use wasm_bindgen::prelude::*;
 

--- a/examples/input-form/crate/Cargo.toml
+++ b/examples/input-form/crate/Cargo.toml
@@ -10,7 +10,6 @@ crate-type = ["cdylib", "rlib"]
 [features]
 
 [dependencies]
-bumpalo = "1.0.2"
 dodrio = { path = "../../.." }
 wasm-bindgen = "0.2"
 console_error_panic_hook = "0.1.1"

--- a/examples/input-form/crate/src/lib.rs
+++ b/examples/input-form/crate/src/lib.rs
@@ -1,4 +1,4 @@
-use bumpalo::Bump;
+use dodrio::bumpalo::{self, Bump};
 use dodrio::{Attribute, Node, Render};
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsCast;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,8 @@
+//! TODO
+
+// Re-export the `bumpalo` crate.
+pub use bumpalo;
+
 use bumpalo::Bump;
 
 // Only `pub` so that the wasm-bindgen bindings work.


### PR DESCRIPTION
This way every crate that uses dodrio doesn't have to manually add bumpalo as a dependency and try and get the right version.