### PR TITLE
Add simple string cache to the change list

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -51,6 +51,11 @@ version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "byteorder"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "cc"
 version = "1.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -87,6 +92,7 @@ dependencies = [
  "console_log 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "dodrio-js-api 0.1.0",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fxhash 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "js-sys 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen 0.2.37 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -226,6 +232,14 @@ dependencies = [
 name = "futures"
 version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "heck"
@@ -621,6 +635,7 @@ dependencies = [
 "checksum backtrace 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)" = "b5b493b66e03090ebc4343eb02f94ff944e0cbc9ac6571491d170ba026741eb5"
 "checksum backtrace-sys 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)" = "797c830ac25ccc92a7f8a7b9862bde440715531514594a6154e3d4a54dd769b6"
 "checksum bumpalo 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "21ef2109240a377370f55ea3ef0b486b46d7b5c0f7455ab0ec676d73f875d58a"
+"checksum byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a019b10a2a7cdeb292db131fc8113e57ea2a908f6e7894b0c3c671893b65dbeb"
 "checksum cc 1.0.29 (registry+https://github.com/rust-lang/crates.io-index)" = "4390a3b5f4f6bce9c1d0c00128379df433e53777fdd30e92f16a529332baec4e"
 "checksum cfg-if 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "11d43355396e872eefb45ce6342e4374ed7bc2b3a502d1b28e36d6e23c05d1f4"
 "checksum console_error_panic_hook 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "b8d976903543e0c48546a91908f21588a680a8c8f984df9a5d69feccb2b2a211"
@@ -629,6 +644,7 @@ dependencies = [
 "checksum failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "795bd83d3abeb9220f257e597aa0080a508b27533824adf336529648f6abf7e2"
 "checksum failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ea1063915fd7ef4309e222a5a07cf9c319fb9c7836b1f89b85458672dbb127e1"
 "checksum futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)" = "49e7653e374fe0d0c12de4250f0bdb60680b8c80eed558c5c7538eec9c89e21b"
+"checksum fxhash 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
 "checksum heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
 "checksum humantime 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3ca7e5f2e110db35f93b837c81797f3714500b81d517bf20c431b16d3ca4f114"
 "checksum itoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "1306f3464951f30e30d12373d31c79fbd52d236e5e896fd92f96ec7babbbe60b"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ futures = "0.1.25"
 wasm-bindgen = "0.2.37"
 wasm-bindgen-futures = "0.3.14"
 js-sys = "0.3.14"
+fxhash = "0.2.1"
 log = { version = "0.4.6", optional = true }
 
 [dependencies.web-sys]

--- a/src/change_list.rs
+++ b/src/change_list.rs
@@ -1,7 +1,7 @@
 use crate::Listener;
 use bumpalo::Bump;
 use std::cell::Cell;
-use std::collections::HashMap;
+use fxhash::FxHashMap;
 use std::fmt;
 use std::sync::Once;
 use wasm_bindgen::prelude::*;
@@ -41,7 +41,7 @@ struct StringsCacheEntry {
 
 pub(crate) struct ChangeList {
     bump: Bump,
-    strings_cache: HashMap<String, StringsCacheEntry>,
+    strings_cache: FxHashMap<String, StringsCacheEntry>,
     next_string_key: Cell<u32>,
     js: js::ChangeList,
     events_trampoline: Option<Closure<Fn(web_sys::Event, u32, u32)>>,
@@ -78,7 +78,7 @@ impl ChangeList {
         });
 
         let bump = Bump::new();
-        let strings_cache = HashMap::new();
+        let strings_cache = FxHashMap::default();
         let js = js::ChangeList::new(container);
         ChangeList {
             bump,
@@ -321,7 +321,7 @@ impl ChangeList {
 
     pub(crate) fn drop_unused_strings(&mut self) {
         debug!("drop_unused_strings()");
-        let mut new_cache = HashMap::new();
+        let mut new_cache = FxHashMap::default();
         for (key, val) in self.strings_cache.iter() {
             if val.used {
                 new_cache.insert(key.clone(), StringsCacheEntry { key: val.key, used: false });

--- a/src/change_list.rs
+++ b/src/change_list.rs
@@ -1,5 +1,7 @@
 use crate::Listener;
 use bumpalo::Bump;
+use std::cell::Cell;
+use std::collections::HashMap;
 use std::fmt;
 use std::sync::Once;
 use wasm_bindgen::prelude::*;
@@ -32,8 +34,15 @@ pub mod js {
     }
 }
 
+struct StringsCacheEntry {
+    key: u32,
+    used: bool,
+}
+
 pub(crate) struct ChangeList {
     bump: Bump,
+    strings_cache: HashMap<String, StringsCacheEntry>,
+    next_string_key: Cell<u32>,
     js: js::ChangeList,
     events_trampoline: Option<Closure<Fn(web_sys::Event, u32, u32)>>,
 }
@@ -69,9 +78,12 @@ impl ChangeList {
         });
 
         let bump = Bump::new();
+        let strings_cache = HashMap::new();
         let js = js::ChangeList::new(container);
         ChangeList {
             bump,
+            strings_cache,
+            next_string_key: Cell::new(0),
             js,
             events_trampoline: None,
         }
@@ -238,6 +250,24 @@ enum ChangeDiscriminant {
     /// stack.top().removeEventListener(String(pointer, length));
     /// ```
     RemoveEventListener = 13,
+
+    /// Immediates: `(pointer, length, id)`
+    ///
+    /// Stack: `[...] -> [...]`
+    ///
+    /// ```text
+    /// addString(String(pointer, length), id);
+    /// ```
+    AddString = 14,
+
+    /// Immediates: `(id)`
+    ///
+    /// Stack: `[...] -> [...]`
+    ///
+    /// ```text
+    /// dropString(id);
+    /// ```
+    DropString = 15,
 }
 
 // Allocation utilities to ensure that we only allocation sequences of `u32`s
@@ -249,22 +279,62 @@ impl ChangeList {
         self.bump.alloc(discriminant as u32);
     }
 
-    // Note: no 1-immediate opcodes at this time.
+    // Allocate an opcode with one immediate.
+    fn op1(&self, discriminant: ChangeDiscriminant, a: u32) {
+        self.bump.alloc([discriminant as u32, a]);
+    }
 
     // Allocate an opcode with two immediates.
     fn op2(&self, discriminant: ChangeDiscriminant, a: u32, b: u32) {
         self.bump.alloc([discriminant as u32, a, b]);
     }
 
-    // Note: no 3-immediate opcodes at this time.
-
-    // Allocate an opcode with four immediates.
-    fn op4(&self, discriminant: ChangeDiscriminant, a: u32, b: u32, c: u32, d: u32) {
-        self.bump.alloc([discriminant as u32, a, b, c, d]);
+    // Allocate an opcode with three immediates.
+    fn op3(&self, discriminant: ChangeDiscriminant, a: u32, b: u32, c: u32) {
+        self.bump.alloc([discriminant as u32, a, b, c]);
     }
+
+    // Note: no 4-immediate opcodes at this time.
 }
 
 impl ChangeList {
+    fn ensure_string(&mut self, string: &str) -> u32 {
+        let entry = self.strings_cache.get_mut(string);
+        if entry.is_some() {
+            let entry = entry.unwrap();
+            entry.used = true;
+            entry.key
+        } else {
+            let key = self.next_string_key.get();
+            self.next_string_key.set(key + 1);
+            let entry = StringsCacheEntry { key, used: true };
+            self.strings_cache.insert(string.to_string(), entry);
+            self.op3(
+                ChangeDiscriminant::AddString,
+                string.as_ptr() as u32,
+                string.len() as u32,
+                key
+            );
+            key
+        }
+    }
+
+    pub(crate) fn drop_unused_strings(&mut self) {
+        debug!("drop_unused_strings()");
+        let mut new_cache = HashMap::new();
+        for (key, val) in self.strings_cache.iter() {
+            if val.used {
+                new_cache.insert(key.clone(), StringsCacheEntry { key: val.key, used: false });
+            } else {
+                self.op1(
+                    ChangeDiscriminant::DropString,
+                    val.key,
+                );
+            }
+        }
+        self.strings_cache = new_cache;
+    }
+
     pub(crate) fn emit_set_text(&self, text: &str) {
         debug!("emit_set_text({:?})", text);
         self.op2(
@@ -284,23 +354,23 @@ impl ChangeList {
         self.op0(ChangeDiscriminant::ReplaceWith);
     }
 
-    pub(crate) fn emit_set_attribute(&self, name: &str, value: &str) {
+    pub(crate) fn emit_set_attribute(&mut self, name: &str, value: &str) {
         debug!("emit_set_attribute({:?}, {:?})", name, value);
-        self.op4(
+        let name_id = self.ensure_string(name);
+        let value_id = self.ensure_string(value);
+        self.op2(
             ChangeDiscriminant::SetAttribute,
-            name.as_ptr() as u32,
-            name.len() as u32,
-            value.as_ptr() as u32,
-            value.len() as u32,
+            name_id,
+            value_id,
         );
     }
 
-    pub(crate) fn emit_remove_attribute(&self, name: &str) {
+    pub(crate) fn emit_remove_attribute(&mut self, name: &str) {
         debug!("emit_remove_attribute({:?})", name);
-        self.op2(
+        let name_id = self.ensure_string(name);
+        self.op1(
             ChangeDiscriminant::RemoveAttribute,
-            name.as_ptr() as u32,
-            name.len() as u32,
+            name_id,
         );
     }
 
@@ -333,47 +403,47 @@ impl ChangeList {
         );
     }
 
-    pub(crate) fn emit_create_element(&self, tag_name: &str) {
+    pub(crate) fn emit_create_element(&mut self, tag_name: &str) {
         debug!("emit_create_element({:?})", tag_name);
-        self.op2(
+        let tag_name_id = self.ensure_string(tag_name);
+        self.op1(
             ChangeDiscriminant::CreateElement,
-            tag_name.as_ptr() as u32,
-            tag_name.len() as u32,
+            tag_name_id,
         );
     }
 
-    pub(crate) fn emit_new_event_listener(&self, listener: &Listener) {
+    pub(crate) fn emit_new_event_listener(&mut self, listener: &Listener) {
         debug!("emit_new_event_listener({:?})", listener);
         let (a, b) = listener.get_callback_parts();
         debug_assert!(a != 0);
-        self.op4(
+        let event_id = self.ensure_string(listener.event);
+        self.op3(
             ChangeDiscriminant::NewEventListener,
-            listener.event.as_ptr() as u32,
-            listener.event.len() as u32,
+            event_id,
             a,
             b,
         );
     }
 
-    pub(crate) fn emit_update_event_listener(&self, listener: &Listener) {
+    pub(crate) fn emit_update_event_listener(&mut self, listener: &Listener) {
         debug!("emit_update_event_listener({:?})", listener);
         let (a, b) = listener.get_callback_parts();
         debug_assert!(a != 0);
-        self.op4(
+        let event_id = self.ensure_string(listener.event);
+        self.op3(
             ChangeDiscriminant::UpdateEventListener,
-            listener.event.as_ptr() as u32,
-            listener.event.len() as u32,
+            event_id,
             a,
             b,
         );
     }
 
-    pub(crate) fn emit_remove_event_listener(&self, event: &str) {
+    pub(crate) fn emit_remove_event_listener(&mut self, event: &str) {
         debug!("emit_remove_event_listener({:?})", event);
-        self.op2(
+        let event_id = self.ensure_string(event);
+        self.op1(
             ChangeDiscriminant::RemoveEventListener,
-            event.as_ptr() as u32,
-            event.len() as u32,
+            event_id,
         );
     }
 }

--- a/src/vdom.rs
+++ b/src/vdom.rs
@@ -256,6 +256,9 @@ impl VdomInnerExclusive {
 
             self.events_registry = Some(events_registry);
 
+            // Find and drop cached strings that aren't in use anymore.
+            self.change_list.drop_unused_strings();
+
             // Tell JS to apply our diff-generated changes to the physical DOM!
             self.change_list.apply_changes();
         }
@@ -271,7 +274,7 @@ impl VdomInnerExclusive {
         self.current_root = Some(current);
     }
 
-    fn diff<'a>(&self, registry: &mut EventsRegistry, old: Node<'a>, new: Node<'a>) {
+    fn diff<'a>(&mut self, registry: &mut EventsRegistry, old: Node<'a>, new: Node<'a>) {
         // debug!("---------------------------------------------------------");
         // debug!("dodrio::Vdom::diff");
         // debug!("  old = {:#?}", old);
@@ -323,7 +326,7 @@ impl VdomInnerExclusive {
     }
 
     fn diff_listeners<'a>(
-        &self,
+        &mut self,
         registry: &mut EventsRegistry,
         old: &'a [Listener<'a>],
         new: &'a [Listener<'a>],
@@ -357,7 +360,7 @@ impl VdomInnerExclusive {
         }
     }
 
-    fn diff_attributes(&self, old: &[Attribute], new: &[Attribute]) {
+    fn diff_attributes(&mut self, old: &[Attribute], new: &[Attribute]) {
         debug!("  updating attributes");
 
         // Do O(n^2) passes to add/update and remove attributes, since
@@ -392,7 +395,7 @@ impl VdomInnerExclusive {
     }
 
     fn diff_children<'a>(
-        &self,
+        &mut self,
         registry: &mut EventsRegistry,
         old: &'a [Node<'a>],
         new: &'a [Node<'a>],
@@ -449,7 +452,7 @@ impl VdomInnerExclusive {
         }
     }
 
-    fn create<'a>(&self, registry: &mut EventsRegistry, node: Node<'a>) {
+    fn create<'a>(&mut self, registry: &mut EventsRegistry, node: Node<'a>) {
         match node {
             Node::Text(TextNode { text }) => {
                 self.change_list.emit_create_text_node(text);


### PR DESCRIPTION
Note: I'm sure there are lots of things to improve about this. Please feel free to either leave comments, or take this and run with it :) It does improve performance on some simple tests quite meaningfully, though, so I think something along these lines would be good to have.

The change list contains a lot of recurring strings, such as attribute names. In many cases, this also includes things like class names, which are repeated many times in e.g. list displays.

This patch adds a simple cache for those strings. Whenever a string is encountered, it's checked against the cache. If it doesn't exist in the cache, it's added, and an opcode is emitted sending that string to JS.

After computing the full change list, the cache is iterated, and all strings not in use in the current change list are evicted, again emitting an opcode per entry instructing the JS side to drop that string, too.

This seems to strike a reasonable balance between keeping the cache across multiple updates—where it helps in scenarios where e.g. multiple list entries are added one after the other—and wasting memory. In particular, right after a string was sent, it's almost certainly in use in the resulting DOM, so keeping it around in the string cache, too, shouldn't waste memory for the string, just for the cache entry itself.

Note that this patch doesn't use the string cache for text nodes: those are deemed less likely to benefit from the cache.