### PR TITLE
Implement IntoIterator for dodrio::Node

### DIFF
--- a/src/node.rs
+++ b/src/node.rs
@@ -1,6 +1,7 @@
 use crate::{RootRender, VdomWeak};
 use bumpalo::Bump;
 use std::fmt;
+use std::iter;
 use std::mem;
 
 /// A node is either a text node or an element.
@@ -146,6 +147,15 @@ impl<'a> Node<'a> {
     #[inline]
     pub(crate) fn text(text: &'a str) -> Node<'a> {
         Node::Text(TextNode { text })
+    }
+}
+
+impl<'a> IntoIterator for Node<'a> {
+    type Item = Node<'a>;
+    type IntoIter = iter::Once<Self::Item>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        iter::once(self)
     }
 }
 


### PR DESCRIPTION
This patch implements `IntoIterator` for `dodrio::Node`, so that `node.into_iter()` returns an iterator which yields the node and nothing else.

This is helpful for `typed-html`'s Dodrio support, where you have a dynamic code block that returns only a single child, so that you can write

```rust
let wibble = "wibble";

dodrio!(bump,
    <p>{ text(wibble) }</p>
)
```

instead of the cumbersome alternative,

```rust
let wibble = "wibble";

dodrio!(bump,
    <p>{ bumpalo::vec![in &bump; text(wibble)] }</p>
)
```