### PR TITLE
Animate Loop

### DIFF
--- a/examples/game-of-life/src/lib.rs
+++ b/examples/game-of-life/src/lib.rs
@@ -1,5 +1,4 @@
 use dodrio::{bumpalo, Node, Render, RenderContext, Vdom};
-use futures::prelude::*;
 use std::cell::RefCell;
 use std::rc::Rc;
 use wasm_bindgen::{prelude::*, JsCast};
@@ -128,6 +127,10 @@ impl Universe {
 
 /// The rendering implementation for our Game of Life.
 impl Render for Universe {
+    fn pre_render(&mut self, _time: f64) {
+        self.tick();
+    }
+
     fn render<'a>(&self, cx: &mut RenderContext<'a>) -> Node<'a> {
         use dodrio::builder::*;
 
@@ -184,14 +187,6 @@ pub fn run() {
     let weak = vdom.weak();
     let f = Closure::wrap(Box::new(move || {
         weak.schedule_render();
-
-        wasm_bindgen_futures::spawn_local(
-            weak.with_component(|root| {
-                let universe = root.unwrap_mut::<Universe>();
-                universe.tick();
-            })
-            .map_err(|_| wasm_bindgen::throw_str("impossible, we always keep the vdom alive")),
-        );
 
         window
             .request_animation_frame(

--- a/src/render.rs
+++ b/src/render.rs
@@ -39,6 +39,9 @@ pub trait Render {
     /// Render `self` as a virtual DOM. Use the given context's `Bump` for
     /// temporary allocations.
     fn render<'a>(&self, cx: &mut RenderContext<'a>) -> Node<'a>;
+
+    /// Will be invoked before render during animation frame
+    fn pre_render(&mut self, _time: f64) {}
 }
 
 impl<'r, R> Render for &'r R


### PR DESCRIPTION
Work in progress. My biggest gripe with the design is that there's still a two-hop - one animation frame will be the scheduled render, and the next one (?) will be used to schedule the next render.

At this point feedback on the interface would be the most useful, followed by an exploration of getting the task behavior correct.

I'm also not sure how to run the examples to get the debug! macro working.