### PR TITLE
Support keyed children

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -205,6 +205,7 @@ dependencies = [
 name = "dodrio"
 version = "0.1.0"
 dependencies = [
+ "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "bumpalo 2.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "console_log 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -214,6 +215,7 @@ dependencies = [
  "fxhash 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "js-sys 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "longest-increasing-subsequence 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen-futures 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen-test 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -452,6 +454,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "longest-increasing-subsequence"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "memchr"
@@ -968,6 +975,7 @@ dependencies = [
 "checksum lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bc5729f27f159ddd61f4df6228e827e86643d4d3e7c32183cb30a1c08f604a14"
 "checksum libc 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)" = "bedcc7a809076656486ffe045abeeac163da1b558e963a31e29fbfbeba916917"
 "checksum log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c84ec4b527950aa83a329754b01dbe3f58361d1c5efacd1f6d68c494d08a17c6"
+"checksum longest-increasing-subsequence 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b3bd0dd2cd90571056fdb71f6275fada10131182f84899f4b2a916e565d81d86"
 "checksum memchr 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2efc7bc57c883d4a4d6e3246905283d8dae951bb3bd32f49d6ef297f546e1c39"
 "checksum memoffset 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0f9dc261e2b62d7a622bf416ea3c5245cdd5d9a7fcc428c0d06804dfce1775b3"
 "checksum nodrop 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "2f9667ddcc6cc8a43afc9b7917599d7216aa09c463919ea32c59ed6cac8bc945"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,7 +60,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "bumpalo"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -107,7 +107,7 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -116,26 +116,28 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "web-sys 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "web-sys 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "criterion"
-version = "0.2.10"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "cast 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "criterion-plot 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "criterion-plot 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "csv 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_os 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_xoshiro 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rayon 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rayon-core 1.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -145,7 +147,7 @@ dependencies = [
 
 [[package]]
 name = "criterion-plot"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -206,20 +208,20 @@ name = "dodrio"
 version = "0.1.0"
 dependencies = [
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "bumpalo 2.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bumpalo 2.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "console_log 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "criterion 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "criterion 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "dodrio-js-api 0.1.0",
  "futures 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "fxhash 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "js-sys 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "js-sys 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "longest-increasing-subsequence 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen-futures 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen-test 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
- "web-sys 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen-futures 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen-test 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "web-sys 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -230,9 +232,9 @@ dependencies = [
  "console_log 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "dodrio 0.1.0",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen-test 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
- "web-sys 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen-test 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "web-sys 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -242,11 +244,11 @@ dependencies = [
  "console_error_panic_hook 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "dodrio 0.1.0",
  "futures 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
- "js-sys 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen-futures 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen-test 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
- "web-sys 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "js-sys 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen-futures 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen-test 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "web-sys 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -255,9 +257,9 @@ version = "0.1.0"
 dependencies = [
  "console_error_panic_hook 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "dodrio 0.1.0",
- "wasm-bindgen 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen-test 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
- "web-sys 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen-test 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "web-sys 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -266,9 +268,9 @@ version = "0.1.0"
 dependencies = [
  "console_error_panic_hook 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "dodrio 0.1.0",
- "wasm-bindgen 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen-test 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
- "web-sys 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen-test 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "web-sys 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -277,10 +279,10 @@ version = "0.1.0"
 dependencies = [
  "dodrio 0.1.0",
  "futures 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
- "js-sys 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen-futures 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen-test 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "js-sys 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen-futures 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen-test 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -290,9 +292,9 @@ dependencies = [
  "console_error_panic_hook 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "dodrio 0.1.0",
  "dodrio-js-api 0.1.0",
- "js-sys 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
- "web-sys 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "js-sys 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "web-sys 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -304,12 +306,12 @@ dependencies = [
  "console_log 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "dodrio 0.1.0",
  "futures 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
- "js-sys 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "js-sys 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen-futures 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen-test 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
- "web-sys 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen-futures 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen-test 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "web-sys 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -319,11 +321,11 @@ dependencies = [
  "console_error_panic_hook 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "dodrio 0.1.0",
  "futures 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
- "js-sys 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen-futures 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen-test 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
- "web-sys 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "js-sys 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen-futures 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen-test 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "web-sys 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -335,14 +337,14 @@ dependencies = [
  "console_log 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "dodrio 0.1.0",
  "futures 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
- "js-sys 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "js-sys 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen-futures 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen-test 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
- "web-sys 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen-futures 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen-test 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "web-sys 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -431,10 +433,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "js-sys"
-version = "0.3.17"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "wasm-bindgen 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -785,79 +787,79 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.40"
+version = "0.2.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "wasm-bindgen-macro 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen-macro 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.40"
+version = "0.2.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bumpalo 2.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bumpalo 2.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.15.30 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen-shared 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen-shared 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.3.17"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "futures 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
- "js-sys 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "js-sys 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.40"
+version = "0.2.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen-macro-support 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen-macro-support 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.40"
+version = "0.2.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.15.30 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen-backend 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen-shared 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen-backend 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen-shared 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.40"
+version = "0.2.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "wasm-bindgen-test"
-version = "0.2.40"
+version = "0.2.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "console_error_panic_hook 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
- "js-sys 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "js-sys 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "scoped-tls 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen-futures 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen-test-macro 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen-futures 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen-test-macro 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "wasm-bindgen-test-macro"
-version = "0.2.40"
+version = "0.2.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -866,7 +868,7 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-webidl"
-version = "0.2.40"
+version = "0.2.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -875,21 +877,21 @@ dependencies = [
  "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.15.30 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen-backend 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen-backend 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "weedle 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.17"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "env_logger 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "js-sys 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "js-sys 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "sourcefile 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen-webidl 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen-webidl 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -944,7 +946,7 @@ dependencies = [
 "checksum backtrace 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "f106c02a3604afcdc0df5d36cc47b44b55917dbaf3d808f71c163a0ddba64637"
 "checksum backtrace-sys 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)" = "797c830ac25ccc92a7f8a7b9862bde440715531514594a6154e3d4a54dd769b6"
 "checksum bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "228047a76f468627ca71776ecdebd732a3423081fcf5125585bcd7c49886ce12"
-"checksum bumpalo 2.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f6a6bc2ba935b1e2f810787ceba8dfe86cbc164cee55925cae715541186673c4"
+"checksum bumpalo 2.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4639720be048090544634e0402490838995ccdc9d2fe648f528f30d3c33ae71f"
 "checksum byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a019b10a2a7cdeb292db131fc8113e57ea2a908f6e7894b0c3c671893b65dbeb"
 "checksum cast 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "926013f2860c46252efceabb19f4a6b308197505082c609025aa6706c011d427"
 "checksum cc 1.0.34 (registry+https://github.com/rust-lang/crates.io-index)" = "30f813bf45048a18eda9190fd3c6b78644146056740c43172a5a3699118588fd"
@@ -953,8 +955,8 @@ dependencies = [
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 "checksum console_error_panic_hook 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "b8d976903543e0c48546a91908f21588a680a8c8f984df9a5d69feccb2b2a211"
 "checksum console_log 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1e7871d2947441b0fdd8e2bd1ce2a2f75304f896582c0d572162d48290683c48"
-"checksum criterion 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)" = "1c6e5ee5b9652d4f851418c448af105642e1f99e9a2741a8ff45c0d2c911b1e0"
-"checksum criterion-plot 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4107e4a5abb94267e0149922b8ff49dc70a87cc202820fdbfc0d3e1edbdc4b16"
+"checksum criterion 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "0363053954f3e679645fc443321ca128b7b950a6fe288cf5f9335cc22ee58394"
+"checksum criterion-plot 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "76f9212ddf2f4a9eb2d401635190600656a1f88a932ef53d06e7fa4c7e02fb8e"
 "checksum crossbeam-deque 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f739f8c5363aca78cfb059edf753d8f0d36908c348f3d8d1503f03d8b75d9cf3"
 "checksum crossbeam-epoch 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "927121f5407de9956180ff5e936fe3cf4324279280001cd56b669d28ee7e9150"
 "checksum crossbeam-utils 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "2760899e32a1d58d5abb31129f8fae5de75220bc2176e77ff7c627ae45c918d9"
@@ -971,7 +973,7 @@ dependencies = [
 "checksum humantime 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3ca7e5f2e110db35f93b837c81797f3714500b81d517bf20c431b16d3ca4f114"
 "checksum itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5b8467d9c1cebe26feb08c640139247fac215782d35371ade9a2136ed6085358"
 "checksum itoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "1306f3464951f30e30d12373d31c79fbd52d236e5e896fd92f96ec7babbbe60b"
-"checksum js-sys 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)" = "d4bda84b98977341bb6ba1086ecbd9eab8bc929de0f2923c118baf76c21dd0c8"
+"checksum js-sys 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)" = "3c994fd445b81741d77f6bcd227d6ed645b95b35a2ecfd2050767450ff1c0b6d"
 "checksum lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bc5729f27f159ddd61f4df6228e827e86643d4d3e7c32183cb30a1c08f604a14"
 "checksum libc 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)" = "bedcc7a809076656486ffe045abeeac163da1b558e963a31e29fbfbeba916917"
 "checksum log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c84ec4b527950aa83a329754b01dbe3f58361d1c5efacd1f6d68c494d08a17c6"
@@ -1019,16 +1021,16 @@ dependencies = [
 "checksum utf8-ranges 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "796f7e48bef87609f7ade7e06495a87d5cd06c7866e6a5cbfceffc558a243737"
 "checksum version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
 "checksum walkdir 2.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "9d9d7ed3431229a144296213105a390676cc49c9b6a72bd19f3176c98e129fa1"
-"checksum wasm-bindgen 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)" = "9742fc4860f47bede1090a5e4b0cfc33afcd70cfdf45dd28f2cfb02d4662b0dd"
-"checksum wasm-bindgen-backend 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)" = "c6d7f35ecbb4180513cdb9b298543321bcb278670730415cbb3205ff2c66a477"
-"checksum wasm-bindgen-futures 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)" = "67bfbec85e48e8915b6acfa1c4d90b770ce033c96dc2067688f3bccd00d3b9e1"
-"checksum wasm-bindgen-macro 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)" = "e3c86b06bcd28e92e87d2c2ad208889b2f69ea33f79810b91ef660cc3de65a4c"
-"checksum wasm-bindgen-macro-support 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)" = "81d7338dd8c67e193d8ef18e5802dc03d8710456baa792c1c2e66847e57fd389"
-"checksum wasm-bindgen-shared 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)" = "0d57c3b66f2f3e4d96b50f49b7b7e2f4cfcddc88b15744433c98c5c105b26672"
-"checksum wasm-bindgen-test 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)" = "85bbc3ad78a8d59a63a02d59345e8da9a3e0c1617f79e77fd1c3da6e047db63e"
-"checksum wasm-bindgen-test-macro 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)" = "114dfdf01bd3659dd79db05480fbd2751759d1c79cd9edc22f2fe611c866e932"
-"checksum wasm-bindgen-webidl 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)" = "fc7052a577eefce17a439edfce5c2eedc8432fe7457bbe949624cdf946233fa7"
-"checksum web-sys 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)" = "72d02003924c77af871ad74216f828b6e32af776cbb3f5dab3dcde2f2713c012"
+"checksum wasm-bindgen 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)" = "ffde3534e5fa6fd936e3260cd62cd644b8656320e369388f9303c955895e35d4"
+"checksum wasm-bindgen-backend 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)" = "40c0543374a7ae881cdc5d32d19de28d1d1929e92263ffa7e31712cc2d53f9f1"
+"checksum wasm-bindgen-futures 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)" = "0ad171fc1f6e43f97d155d27f4ee5657bd8aa5cce7c497ef3a0a0c5b44618b2d"
+"checksum wasm-bindgen-macro 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)" = "f914c94c2c5f4c9364510ca2429e59c92157ec89429243bcc245e983db990a71"
+"checksum wasm-bindgen-macro-support 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)" = "9168c413491e4233db7b6884f09a43beb00c14d11d947ffd165242daa48a2385"
+"checksum wasm-bindgen-shared 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)" = "326c32126e1a157b6ced7400061a84ac5b11182b2cda6edad7314eb3ae9ac9fe"
+"checksum wasm-bindgen-test 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)" = "8aed4ef1aa56f2ef4aff593c516de6a3e48711c703b3f7415c9151a7c9babd17"
+"checksum wasm-bindgen-test-macro 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)" = "eb477c50f3c9a9ecd99c78fb9bd3b6599d414b918d5f72165b12c53738011ae1"
+"checksum wasm-bindgen-webidl 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)" = "613dbf4d7d3bf10aeb212b35de14a8ef07222c26526d4f931061a83fc9e2a851"
+"checksum web-sys 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)" = "24129e4be2281109b3e15a328d3d7f233ee232a5405f75ba1e9bb59a25ebc4d4"
 "checksum weedle 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "26a4c67f132386d965390b8a734d5d10adbcd30eb5cc74bd9229af8b83f10044"
 "checksum winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "f10e386af2b13e47c89e7236a7a14a086791a2b88ebad6df9bf42040195cf770"
 "checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,8 @@ wasm-bindgen-futures = "0.3.17"
 js-sys = "0.3.17"
 fxhash = "0.2.1"
 log = { version = "0.4.6", optional = true }
+bitflags = "1.0.4"
+longest-increasing-subsequence = "0.1.0"
 
 [dependencies.web-sys]
 version = "0.3.17"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,19 +34,19 @@ required-features = ["xxx-unstable-internal-use-only"]
 xxx-unstable-internal-use-only = []
 
 [dependencies]
-bumpalo = "2.3.0"
+bumpalo = "2.4.1"
 cfg-if = "0.1.7"
 futures = "0.1.26"
-wasm-bindgen = "0.2.40"
-wasm-bindgen-futures = "0.3.17"
-js-sys = "0.3.17"
+wasm-bindgen = "0.2.42"
+wasm-bindgen-futures = "0.3.19"
+js-sys = "0.3.19"
 fxhash = "0.2.1"
 log = { version = "0.4.6", optional = true }
 bitflags = "1.0.4"
 longest-increasing-subsequence = "0.1.0"
 
 [dependencies.web-sys]
-version = "0.3.17"
+version = "0.3.19"
 features = [
   "console",
   "Document",
@@ -60,10 +60,10 @@ features = [
 console_log = "0.1.2"
 dodrio-js-api = { version = "=0.1.0", path = "./crates/js-api" }
 log = "0.4.6"
-wasm-bindgen-test = "0.2.40"
+wasm-bindgen-test = "0.2.42"
 
 [dev-dependencies.web-sys]
-version = "0.3.17"
+version = "0.3.19"
 features = [
   "Attr",
   "EventTarget",
@@ -73,7 +73,7 @@ features = [
 ]
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
-criterion = "0.2.10"
+criterion = "0.2.11"
 
 [profile.bench]
 debug = true

--- a/crates/js-api/Cargo.toml
+++ b/crates/js-api/Cargo.toml
@@ -14,10 +14,10 @@ travis-ci = { repository = "fitzgen/dodrio" }
 
 [dependencies]
 dodrio = { version = "=0.1.0", path = "../.." }
-wasm-bindgen = "0.2.40"
-js-sys = "0.3.17"
-wasm-bindgen-futures = "0.3.17"
+wasm-bindgen = "0.2.42"
+js-sys = "0.3.19"
+wasm-bindgen-futures = "0.3.19"
 futures = "0.1.26"
 
 [dev-dependencies]
-wasm-bindgen-test = "0.2.40"
+wasm-bindgen-test = "0.2.42"

--- a/examples/counter/Cargo.toml
+++ b/examples/counter/Cargo.toml
@@ -14,10 +14,10 @@ console_error_panic_hook = "0.1.6"
 console_log = "0.1.2"
 dodrio = { path = "../.." }
 log = "0.4.6"
-wasm-bindgen = "0.2.40"
+wasm-bindgen = "0.2.42"
 
 [dependencies.web-sys]
-version = "0.3.17"
+version = "0.3.19"
 features = [
   "console",
   "Document",
@@ -30,4 +30,4 @@ features = [
 ]
 
 [dev-dependencies]
-wasm-bindgen-test = "0.2.40"
+wasm-bindgen-test = "0.2.42"

--- a/examples/game-of-life/Cargo.toml
+++ b/examples/game-of-life/Cargo.toml
@@ -11,14 +11,14 @@ crate-type = ["cdylib"]
 
 [dependencies]
 dodrio = { path = "../.." }
-wasm-bindgen = "0.2.40"
+wasm-bindgen = "0.2.42"
 console_error_panic_hook = "0.1.6"
-js-sys = "0.3.17"
-wasm-bindgen-futures = "0.3.17"
+js-sys = "0.3.19"
+wasm-bindgen-futures = "0.3.19"
 futures = "0.1.26"
 
 [dependencies.web-sys]
-version = "0.3.17"
+version = "0.3.19"
 features = [
   "Document",
   "HtmlElement",
@@ -27,4 +27,4 @@ features = [
 ]
 
 [dev-dependencies]
-wasm-bindgen-test = "0.2.40"
+wasm-bindgen-test = "0.2.42"

--- a/examples/hello-world/Cargo.toml
+++ b/examples/hello-world/Cargo.toml
@@ -11,11 +11,11 @@ crate-type = ["cdylib"]
 
 [dependencies]
 dodrio = { path = "../.." }
-wasm-bindgen = "0.2.40"
+wasm-bindgen = "0.2.42"
 console_error_panic_hook = "0.1.6"
 
 [dependencies.web-sys]
-version = "0.3.17"
+version = "0.3.19"
 features = [
   "Document",
   "HtmlElement",
@@ -24,4 +24,4 @@ features = [
 ]
 
 [dev-dependencies]
-wasm-bindgen-test = "0.2.40"
+wasm-bindgen-test = "0.2.42"

--- a/examples/input-form/Cargo.toml
+++ b/examples/input-form/Cargo.toml
@@ -11,11 +11,11 @@ crate-type = ["cdylib"]
 
 [dependencies]
 dodrio = { path = "../.." }
-wasm-bindgen = "0.2.40"
+wasm-bindgen = "0.2.42"
 console_error_panic_hook = "0.1.6"
 
 [dependencies.web-sys]
-version = "0.3.17"
+version = "0.3.19"
 features = [
   "console",
   "Document",
@@ -29,4 +29,4 @@ features = [
 ]
 
 [dev-dependencies]
-wasm-bindgen-test = "0.2.40"
+wasm-bindgen-test = "0.2.42"

--- a/examples/js-component/Cargo.toml
+++ b/examples/js-component/Cargo.toml
@@ -12,12 +12,12 @@ crate-type = ["cdylib"]
 [dependencies]
 dodrio = { path = "../.." }
 dodrio-js-api = { path = "../../crates/js-api" }
-wasm-bindgen = "0.2.40"
+wasm-bindgen = "0.2.42"
 console_error_panic_hook = "0.1.6"
-js-sys = "0.3.17"
+js-sys = "0.3.19"
 
 [dependencies.web-sys]
-version = "0.3.17"
+version = "0.3.19"
 features = [
   "Document",
   "HtmlElement",

--- a/examples/moire/Cargo.toml
+++ b/examples/moire/Cargo.toml
@@ -12,16 +12,16 @@ cfg-if = "0.1.7"
 dodrio = { path = "../.." }
 futures = "0.1.26"
 log = "0.4.6"
-wasm-bindgen = "0.2.40"
-wasm-bindgen-futures = "0.3.17"
+wasm-bindgen = "0.2.42"
+wasm-bindgen-futures = "0.3.19"
 
 # Optional dependencies for logging.
 console_error_panic_hook = { optional = true, version = "0.1.6" }
 console_log = { optional = true, version = "0.1.2" }
-js-sys = "0.3.17"
+js-sys = "0.3.19"
 
 [dependencies.web-sys]
-version = "0.3.17"
+version = "0.3.19"
 features = [
   "Document",
   "Element",
@@ -35,7 +35,7 @@ features = [
 ]
 
 [dev-dependencies]
-wasm-bindgen-test = "0.2.40"
+wasm-bindgen-test = "0.2.42"
 
 [features]
 logging = [

--- a/examples/sierpinski-triangle/Cargo.toml
+++ b/examples/sierpinski-triangle/Cargo.toml
@@ -9,14 +9,14 @@ crate-type = ["cdylib"]
 
 [dependencies]
 dodrio = { path = "../.." }
-wasm-bindgen = "0.2.40"
+wasm-bindgen = "0.2.42"
 console_error_panic_hook = "0.1.6"
-js-sys = "0.3.17"
-wasm-bindgen-futures = "0.3.17"
+js-sys = "0.3.19"
+wasm-bindgen-futures = "0.3.19"
 futures = "0.1.26"
 
 [dependencies.web-sys]
-version = "0.3.17"
+version = "0.3.19"
 features = [
   "Document",
   "HtmlElement",
@@ -26,4 +26,4 @@ features = [
 ]
 
 [dev-dependencies]
-wasm-bindgen-test = "0.2.40"
+wasm-bindgen-test = "0.2.42"

--- a/examples/todomvc/Cargo.toml
+++ b/examples/todomvc/Cargo.toml
@@ -8,11 +8,11 @@ version = "0.1.0"
 cfg-if = "0.1.7"
 dodrio = { path = "../.."  }
 futures = "0.1.26"
-js-sys = "0.3.17"
+js-sys = "0.3.19"
 serde = { features = ["derive"], version = "1.0.90" }
 serde_json = "1.0.39"
-wasm-bindgen = "0.2.40"
-wasm-bindgen-futures = "0.3.17"
+wasm-bindgen = "0.2.42"
+wasm-bindgen-futures = "0.3.19"
 
 # Optional dependencies for logging.
 console_error_panic_hook = { optional = true, version = "0.1.6" }
@@ -20,7 +20,7 @@ console_log = { optional = true, version = "0.1.2" }
 log = { optional = true, version = "0.4.6" }
 
 [dependencies.web-sys]
-version = "0.3.17"
+version = "0.3.19"
 features = [
     "Document",
     "Event",
@@ -35,7 +35,7 @@ features = [
 ]
 
 [dev-dependencies]
-wasm-bindgen-test = "0.2.40"
+wasm-bindgen-test = "0.2.42"
 
 [features]
 logging = [

--- a/js/change-list-interpreter.js
+++ b/js/change-list-interpreter.js
@@ -288,6 +288,7 @@ export class ChangeListInterpreter {
 
     this.ranges.length = 0;
     this.stack.length = 0;
+    this.temporaries.length = 0;
   }
 
   applyChangeRange(mem8, mem32, start, len) {

--- a/js/change-list-interpreter.js
+++ b/js/change-list-interpreter.js
@@ -188,13 +188,57 @@ const OP_TABLE = [
   },
 
   // 17
-  function setAttributeNS(interpreter, mem8, mem32, i) {
-    const nameId = mem32[i++];
-    const valueId = mem32[i++];
-    const name = interpreter.getCachedString(nameId);
-    const value = interpreter.getCachedString(valueId);
-    const node = top(interpreter.stack);
-    node.setAttributeNS(null, name, value);
+  function saveChildrenToTemporaries(interpreter, mem8, mem32, i) {
+    let temp = mem32[i++];
+    const start = mem32[i++];
+    const end = mem32[i++];
+    const parent = top(interpreter.stack);
+    const children = parent.childNodes;
+    for (let i = start; i < end; i++) {
+      interpreter.temporaries[temp++] = children[i];
+    }
+    return i;
+  },
+
+  // 18
+  function pushChild(interpreter, mem8, mem32, i) {
+    const parent = top(interpreter.stack);
+    const n = mem32[i++];
+    const child = parent.childNodes[n];
+    interpreter.stack.push(child);
+    return i;
+  },
+
+  // 19
+  function pushTemporary(interpreter, mem8, mem32, i) {
+    const temp = mem32[i++];
+    interpreter.stack.push(interpreter.temporaries[temp]);
+    return i;
+  },
+
+  // 20
+  function insertBefore(interpreter, mem8, mem32, i) {
+    const before = interpreter.stack.pop();
+    const after = interpreter.stack.pop();
+    after.parentNode.insertBefore(before, after);
+    interpreter.stack.push(before);
+    return i;
+  },
+
+  // 21
+  function pushLastChild(interpreter, mem8, mem32, i) {
+    const parent = top(interpreter.stack);
+    const child = parent.lastChild;
+    interpreter.stack.push(child);
+    return i;
+  },
+
+  // 22
+  function removeChild(interpreter, mem8, mem32, i) {
+    const n = mem32[i++];
+    const parent = top(interpreter.stack);
+    const child = parent.childNodes[n];
+    child.remove();
     return i;
   }
 ];
@@ -206,6 +250,7 @@ export class ChangeListInterpreter {
     this.ranges = [];
     this.stack = [];
     this.strings = new Map();
+    this.temporaries = [];
   }
 
   unmount() {
@@ -218,6 +263,7 @@ export class ChangeListInterpreter {
     this.ranges = null;
     this.stack = null;
     this.strings = null;
+    this.temporaries = null;
   }
 
   addChangeListRange(start, len) {

--- a/src/cached.rs
+++ b/src/cached.rs
@@ -1,4 +1,8 @@
-use crate::{cached_set::CachedSet, node::CachedNode, Node, Render, RenderContext};
+use crate::{
+    cached_set::CachedSet,
+    node::{CachedNode, NodeKey},
+    Node, Render, RenderContext,
+};
 use std::cell::Cell;
 use std::ops::{Deref, DerefMut};
 
@@ -146,13 +150,13 @@ where
                 cached
             }
             _ => {
-                let mut flags = Default::default();
+                let mut key = NodeKey::NONE;
                 let id = CachedSet::insert(cx, |nested_cx| {
                     let node = self.inner.render(nested_cx);
-                    flags = node.flags();
+                    key = node.key();
                     node
                 });
-                let cached = CachedNode { id, flags };
+                let cached = CachedNode { id, key };
                 self.cached.set(Some(cached));
                 cached
             }

--- a/src/cached_set.rs
+++ b/src/cached_set.rs
@@ -64,7 +64,6 @@ impl CachedSet {
         self.items.retain(|id, entry| {
             let keep = marked.contains(id);
             if !keep {
-                debug!("CachedSet::gc: removing {:?}", id);
                 let node: &Node = unsafe { &*entry.node };
                 registry.remove_subtree(node);
             }
@@ -129,7 +128,6 @@ impl CachedSet {
 
         let mut set = set.borrow_mut();
         let id = set.next_id();
-        debug!("CachedSet::insert: id = {:?}; entry = {:?}", id, entry);
         set.items.insert(id, entry);
         id
     }
@@ -141,7 +139,6 @@ impl CachedSet {
 
     /// Get the node for the given cache id.
     pub fn get(&self, mut id: CacheId) -> &Node {
-        debug!("CachedSet::get: id = {:?}", id);
         loop {
             let entry = self
                 .items

--- a/src/cached_set.rs
+++ b/src/cached_set.rs
@@ -140,7 +140,7 @@ impl CachedSet {
     }
 
     /// Get the node for the given cache id.
-    pub fn get(&self, mut id: CacheId) -> Node {
+    pub fn get(&self, mut id: CacheId) -> &Node {
         debug!("CachedSet::get: id = {:?}", id);
         loop {
             let entry = self
@@ -152,7 +152,7 @@ impl CachedSet {
                 id = c.id;
                 continue;
             } else {
-                return node.clone();
+                return node;
             }
         }
     }

--- a/src/change_list/emitter.rs
+++ b/src/change_list/emitter.rs
@@ -201,4 +201,60 @@ define_change_list_instructions! {
     /// stack.push(document.createElementNS(tag_name, namespace))
     /// ```
     create_element_ns(tag_name_key, namespace_key) = 16,
+
+    /// Stack: `[...] -> [...]`
+    ///
+    /// ```text
+    /// parent = stack.top()
+    /// children = parent.childNodes
+    /// temp = temp_base
+    /// for i in start .. end:
+    ///     temporaries[temp] = children[i]
+    ///     temp += 1
+    /// ```
+    save_children_to_temporaries(temp_base, start, end) = 17,
+
+    /// Stack: `[... Node] -> [... Node Node]`
+    ///
+    /// ```text
+    /// parent = stack.top()
+    /// child = parent.childNodes[n]
+    /// stack.push(child)
+    /// ```
+    push_child(n) = 18,
+
+    /// Stack: `[...] -> [... Node]`
+    ///
+    /// ```text
+    /// stack.push(temporaries[temp])
+    /// ```
+    push_temporary(temp) = 19,
+
+    /// Stack: `[... Node Node] -> [... Node]`
+    ///
+    /// ```text
+    /// before = stack.pop()
+    /// after = stack.pop()
+    /// after.insertBefore(before)
+    /// stack.push(before)
+    /// ```
+    insert_before() = 20,
+
+    /// Stack: `[... Node] -> [... Node Node]`
+    ///
+    /// ```text
+    /// parent = stack.top()
+    /// child = parent.lastChild
+    /// stack.push(child)
+    /// ```
+    push_last_child() = 21,
+
+    /// Stack: `[... Node] -> [... Node]`
+    ///
+    /// ```text
+    /// parent = stack.top()
+    /// child = parent.childNodes[n]
+    /// child.remove()
+    /// ```
+    remove_child(n) = 22,
 }

--- a/src/change_list/strings.rs
+++ b/src/change_list/strings.rs
@@ -45,8 +45,7 @@ impl StringsCache {
     }
 
     pub fn drop_unused_strings(&mut self, emitter: &InstructionEmitter) {
-        debug!("drop_unused_strings()");
-        self.entries.retain(|_string, entry| {
+        self.entries.retain(|string, entry| {
             if entry.used {
                 // Since this entry was used during while rendering this frame,
                 // it is likely going to be used for the next frame as well. So
@@ -57,7 +56,9 @@ impl StringsCache {
                 entry.used = false;
                 true
             } else {
-                emitter.drop_cached_string(entry.key.into());
+                let key = entry.key.into();
+                debug!("emit: drop_cached_string({}) = {:?}", key, string);
+                emitter.drop_cached_string(key);
                 false
             }
         });

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -190,6 +190,13 @@ fn diff_children(
     new: &[Node],
     cached_roots: &mut FxHashSet<CacheId>,
 ) {
+    if new.is_empty() {
+        if !old.is_empty() {
+            remove_children(change_list, registry, old);
+        }
+        return;
+    }
+
     debug!("  updating children shared by old and new");
 
     let num_children_to_diff = cmp::min(new.len(), old.len());
@@ -253,6 +260,19 @@ fn diff_children(
     if pushed {
         change_list.pop();
     }
+}
+
+fn remove_children(
+    change_list: &mut ChangeListBuilder,
+    registry: &mut EventsRegistry,
+    old: &[Node],
+) {
+    for child in old {
+        registry.remove_subtree(child);
+    }
+    // Fast way to remove all children: set the node's textContent to an empty
+    // string.
+    change_list.set_text("");
 }
 
 fn create(

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -2,11 +2,22 @@ use crate::{
     cached_set::{CacheId, CachedSet},
     change_list::ChangeListBuilder,
     events::EventsRegistry,
-    node::{Attribute, ElementNode, Listener, Node, NodeKind, TextNode},
+    node::{Attribute, ElementNode, ElementNodeFlags, Listener, Node, NodeKind, TextNode},
 };
-use fxhash::FxHashSet;
-use std::cmp;
+use fxhash::{FxHashMap, FxHashSet};
+use std::cmp::Ordering;
+use std::ops::Range;
+use std::u32;
 
+// Diff the `old` node with the `new` node. Emits instructions to modify a
+// physical DOM node that reflects `old` into something that reflects `new`.
+//
+// Upon entry to this function, the physical DOM node must be on the top of the
+// stack:
+//
+//     [... node]
+//
+// The stack is in the same state when this function exits.
 pub(crate) fn diff(
     cached_set: &CachedSet,
     change_list: &mut ChangeListBuilder,
@@ -20,22 +31,18 @@ pub(crate) fn diff(
             &NodeKind::Text(TextNode { text: new_text }),
             &NodeKind::Text(TextNode { text: old_text }),
         ) => {
-            debug!("  both are text nodes");
             if new_text != old_text {
-                debug!("  text needs updating");
                 change_list.set_text(new_text);
             }
         }
 
         (&NodeKind::Text(_), &NodeKind::Element(_)) => {
-            debug!("  replacing a text node with an element");
             create(cached_set, change_list, registry, new, cached_roots);
             registry.remove_subtree(&old);
             change_list.replace_with();
         }
 
         (&NodeKind::Element(_), &NodeKind::Text(_)) => {
-            debug!("  replacing an element with a text node");
             create(cached_set, change_list, registry, new, cached_roots);
             // Note: text nodes cannot have event listeners, so we don't need to
             // remove the old node's listeners from our registry her.
@@ -44,6 +51,7 @@ pub(crate) fn diff(
 
         (
             &NodeKind::Element(ElementNode {
+                flags: new_flags,
                 tag_name: new_tag_name,
                 listeners: new_listeners,
                 attributes: new_attributes,
@@ -51,6 +59,7 @@ pub(crate) fn diff(
                 namespace: new_namespace,
             }),
             &NodeKind::Element(ElementNode {
+                flags: old_flags,
                 tag_name: old_tag_name,
                 listeners: old_listeners,
                 attributes: old_attributes,
@@ -58,9 +67,7 @@ pub(crate) fn diff(
                 namespace: old_namespace,
             }),
         ) => {
-            debug!("  updating an element");
             if new_tag_name != old_tag_name || new_namespace != old_namespace {
-                debug!("  different tag names or namespaces; creating new element and replacing old element");
                 create(cached_set, change_list, registry, new, cached_roots);
                 registry.remove_subtree(&old);
                 change_list.replace_with();
@@ -72,6 +79,8 @@ pub(crate) fn diff(
                 cached_set,
                 change_list,
                 registry,
+                new_flags,
+                old_flags,
                 old_children,
                 new_children,
                 cached_roots,
@@ -113,14 +122,19 @@ pub(crate) fn diff(
     }
 }
 
+// Diff event listeners between `old` and `new`.
+//
+// The listeners' node must be on top of the stack:
+//
+//     [... node]
+//
+// The stack is left unchanged.
 fn diff_listeners(
     change_list: &mut ChangeListBuilder,
     registry: &mut EventsRegistry,
     old: &[Listener],
     new: &[Listener],
 ) {
-    debug!("  updating event listeners");
-
     'outer1: for new_l in new {
         unsafe {
             // Safety relies on removing `new_l` from the registry manually at
@@ -151,9 +165,14 @@ fn diff_listeners(
     }
 }
 
+// Diff a node's attributes.
+//
+// The attributes' node must be on top of the stack:
+//
+//     [... node]
+//
+// The stack is left unchanged.
 fn diff_attributes(change_list: &mut ChangeListBuilder, old: &[Attribute], new: &[Attribute]) {
-    debug!("  updating attributes");
-
     // Do O(n^2) passes to add/update and remove attributes, since
     // there are almost always very few attributes.
     'outer: for new_attr in new {
@@ -182,7 +201,65 @@ fn diff_attributes(change_list: &mut ChangeListBuilder, old: &[Attribute], new: 
     }
 }
 
+// Diff the given set of old and new children.
+//
+// The parent must be on top of the stack when this function is entered:
+//
+//     [... parent]
+//
+// The stack is in the same state when this function returns.
 fn diff_children(
+    cached_set: &CachedSet,
+    change_list: &mut ChangeListBuilder,
+    registry: &mut EventsRegistry,
+    new_flags: ElementNodeFlags,
+    old_flags: ElementNodeFlags,
+    old: &[Node],
+    new: &[Node],
+    cached_roots: &mut FxHashSet<CacheId>,
+) {
+    if new.is_empty() {
+        if !old.is_empty() {
+            remove_all_children(change_list, registry, old);
+        }
+        return;
+    }
+
+    if old.is_empty() {
+        create_and_append_children(cached_set, change_list, registry, new, cached_roots);
+        return;
+    }
+
+    if new_flags.has_keyed_children() && old_flags.has_keyed_children() {
+        let t = change_list.next_temporary();
+        diff_keyed_children(cached_set, change_list, registry, old, new, cached_roots);
+        change_list.set_next_temporary(t);
+    } else {
+        diff_non_keyed_children(cached_set, change_list, registry, old, new, cached_roots);
+    }
+}
+
+// Diffing "keyed" children.
+//
+// With keyed children, we care about whether we delete, move, or create nodes
+// versus mutate existing nodes in place. Presumably there is some sort of CSS
+// transition animation that makes the virtual DOM diffing algorithm
+// observable. By specifying keys for nodes, we know which virtual DOM nodes
+// must reuse (or not reuse) the same physical DOM nodes.
+//
+// This is loosely based on Inferno's keyed patching implementation. However, we
+// have to modify the algorithm since we are compiling the diff down into change
+// list instructions that will be executed later, rather than applying the
+// changes to the DOM directly as we compare virtual DOMs.
+//
+// https://github.com/infernojs/inferno/blob/36fd96/packages/inferno/src/DOM/patching.ts#L530-L739
+//
+// When entering this function, the parent must be on top of the stack:
+//
+//     [... parent]
+//
+// Upon exiting, the stack is in the same state.
+fn diff_keyed_children(
     cached_set: &CachedSet,
     change_list: &mut ChangeListBuilder,
     registry: &mut EventsRegistry,
@@ -190,36 +267,501 @@ fn diff_children(
     new: &[Node],
     cached_roots: &mut FxHashSet<CacheId>,
 ) {
-    if new.is_empty() {
-        if !old.is_empty() {
-            remove_children(change_list, registry, old);
-        }
-        return;
+    // First up, we diff all the nodes with the same key at the beginning of the
+    // children.
+    //
+    // `shared_prefix_count` is the count of how many nodes at the start of
+    // `new` and `old` share the same keys.
+    let shared_prefix_count =
+        match diff_keyed_prefix(cached_set, change_list, registry, old, new, cached_roots) {
+            KeyedPrefixResult::Finished => return,
+            KeyedPrefixResult::MoreWorkToDo(count) => count,
+        };
+
+    // Next, we find out how many of the nodes at the end of the children have
+    // the same key. We do _not_ diff them yet, since we want to emit the change
+    // list instructions such that they can be applied in a single pass over the
+    // DOM. Instead, we just save this information for later.
+    //
+    // `shared_suffix_count` is the count of how many nodes at the end of `new`
+    // and `old` share the same keys.
+    let shared_suffix_count = old[shared_prefix_count..]
+        .iter()
+        .rev()
+        .zip(new[shared_prefix_count..].iter().rev())
+        .take_while(|&(old, new)| old.key() == new.key())
+        .count();
+
+    let old_shared_suffix_start = old.len() - shared_suffix_count;
+    let new_shared_suffix_start = new.len() - shared_suffix_count;
+
+    // Ok, we now hopefully have a smaller range of children in the middle
+    // within which to re-order nodes with the same keys, remove old nodes with
+    // now-unused keys, and create new nodes with fresh keys.
+    diff_keyed_middle(
+        cached_set,
+        change_list,
+        registry,
+        &old[shared_prefix_count..old_shared_suffix_start],
+        &new[shared_prefix_count..new_shared_suffix_start],
+        cached_roots,
+        shared_prefix_count,
+        shared_suffix_count,
+        old_shared_suffix_start,
+    );
+
+    // Finally, diff the nodes at the end of `old` and `new` that share keys.
+    let old_suffix = &old[old_shared_suffix_start..];
+    let new_suffix = &new[new_shared_suffix_start..];
+    debug_assert_eq!(old_suffix.len(), new_suffix.len());
+    if !old_suffix.is_empty() {
+        diff_keyed_suffix(
+            cached_set,
+            change_list,
+            registry,
+            old_suffix,
+            new_suffix,
+            cached_roots,
+            new_shared_suffix_start,
+        );
     }
+}
 
-    if old.is_empty() {
-        create_children(cached_set, change_list, registry, new, cached_roots);
-        return;
-    }
+enum KeyedPrefixResult {
+    // Fast path: we finished diffing all the children just by looking at the
+    // prefix of shared keys!
+    Finished,
+    // There is more diffing work to do. Here is a count of how many children at
+    // the beginning of `new` and `old` we already processed.
+    MoreWorkToDo(usize),
+}
 
-    debug!("  updating children shared by old and new");
-
-    let num_children_to_diff = cmp::min(new.len(), old.len());
-    let mut new_children = new.iter();
-    let mut old_children = old.iter();
+// Diff the prefix of children in `new` and `old` that share the same keys in
+// the same order.
+//
+// Upon entry of this function, the stack must be:
+//
+//     [... parent]
+//
+// Upon exit, the stack is the same.
+fn diff_keyed_prefix(
+    cached_set: &CachedSet,
+    change_list: &mut ChangeListBuilder,
+    registry: &mut EventsRegistry,
+    old: &[Node],
+    new: &[Node],
+    cached_roots: &mut FxHashSet<CacheId>,
+) -> KeyedPrefixResult {
     let mut pushed = false;
+    let mut shared_prefix_count = 0;
 
-    for (i, (new_child, old_child)) in new_children
-        .by_ref()
-        .zip(old_children.by_ref())
-        .take(num_children_to_diff)
-        .enumerate()
-    {
-        if i == 0 {
+    for (old, new) in old.iter().zip(new.iter()) {
+        if old.key() != new.key() {
+            break;
+        }
+
+        if pushed {
+            debug_assert!(shared_prefix_count > 0);
+            change_list.pop_push_next_sibling();
+        } else {
+            debug_assert_eq!(shared_prefix_count, 0);
             change_list.push_first_child();
             pushed = true;
+        }
+
+        diff(cached_set, change_list, registry, old, new, cached_roots);
+        shared_prefix_count += 1;
+
+        // At the end of the loop, the stack looks like
+        //
+        //     [... parent child_we_just_diffed]
+        debug_assert!(pushed);
+    }
+
+    // If that was all of the old children, then create and append the remaining
+    // new children and we're finished.
+    if shared_prefix_count == old.len() {
+        debug_assert!(
+            pushed,
+            "we handle the case of empty children before calling this method, so
+             `shared_prefix_count` must be greater than zero, and therefore we
+               must have pushed in the above loop"
+        );
+        change_list.pop();
+        create_and_append_children(
+            cached_set,
+            change_list,
+            registry,
+            &new[shared_prefix_count..],
+            cached_roots,
+        );
+        return KeyedPrefixResult::Finished;
+    }
+
+    // And if that was all of the new children, then remove all of the remaining
+    // old children and we're finished.
+    if shared_prefix_count == new.len() {
+        // Same as above.
+        debug_assert!(pushed);
+        change_list.pop_push_next_sibling();
+        change_list.remove_self_and_next_siblings();
+        return KeyedPrefixResult::Finished;
+    }
+
+    if pushed {
+        debug_assert!(shared_prefix_count > 0);
+        change_list.pop();
+    }
+    KeyedPrefixResult::MoreWorkToDo(shared_prefix_count)
+}
+
+// The most-general, expensive code path for keyed children diffing.
+//
+// We find the longest subsequence within `old` of children that are relatively
+// ordered the same way in `new` (via finding a longest-increasing-subsequence
+// of the old child's index within `new`). The children that are elements of
+// this subsequence will remain in place, minimizing the number of DOM moves we
+// will have to do.
+//
+// Upon entry to this function, the stack must be:
+//
+//     [... parent]
+//
+// Upon exit from this function, it will be restored to that same state.
+fn diff_keyed_middle(
+    cached_set: &CachedSet,
+    change_list: &mut ChangeListBuilder,
+    registry: &mut EventsRegistry,
+    old: &[Node],
+    new: &[Node],
+    cached_roots: &mut FxHashSet<CacheId>,
+    shared_prefix_count: usize,
+    shared_suffix_count: usize,
+    old_shared_suffix_start: usize,
+) {
+    // Should have already diffed the shared-key prefixes and suffixes.
+    debug_assert_ne!(new.first().map(|n| n.key()), old.first().map(|o| o.key()));
+    debug_assert_ne!(new.last().map(|n| n.key()), old.last().map(|o| o.key()));
+
+    // The algorithm below relies upon using `u32::MAX` as a sentinel
+    // value, so if we have that many new nodes, it won't work. This
+    // check is a bit academic (hence only enabled in debug), since
+    // wasm32 doesn't have enough address space to hold that many nodes
+    // in memory.
+    debug_assert!(new.len() < u32::MAX as usize);
+
+    // Map from each `old` node's key to its index within `old`.
+    let mut old_key_to_old_index = FxHashMap::default();
+    old_key_to_old_index.reserve(old.len());
+    old_key_to_old_index.extend(old.iter().enumerate().map(|(i, o)| (o.key(), i)));
+
+    // The set of shared keys between `new` and `old`.
+    let mut shared_keys = FxHashSet::default();
+    // Map from each index in `new` to the index of the node in `old` that
+    // has the same key.
+    let mut new_index_to_old_index = Vec::with_capacity(new.len());
+    new_index_to_old_index.extend(new.iter().map(|n| {
+        let key = n.key();
+        if let Some(&i) = old_key_to_old_index.get(&key) {
+            shared_keys.insert(key);
+            i
         } else {
-            debug_assert!(pushed);
+            u32::MAX as usize
+        }
+    }));
+
+    // If none of the old keys are reused by the new children, then we
+    // remove all the remaining old children and create the new children
+    // afresh.
+    if shared_suffix_count == 0 && shared_keys.is_empty() {
+        if shared_prefix_count == 0 {
+            remove_all_children(change_list, registry, old);
+        } else {
+            change_list.pop_push_next_sibling();
+            remove_self_and_next_siblings(change_list, registry, &old[shared_prefix_count..]);
+        }
+        create_and_append_children(cached_set, change_list, registry, new, cached_roots);
+        return;
+    }
+
+    // The longest increasing subsequence within `new_index_to_old_index` in
+    // reverse order (since `lis_with` adds the indices in reverse
+    // order). We will leave these nodes in place in the DOM, and only move
+    // nodes that are not part of the LIS. This results in the minimum
+    // number of DOM nodes moved.
+    let mut reverse_lis = Vec::with_capacity(new_index_to_old_index.len());
+    let mut predecessors = vec![0; new_index_to_old_index.len()];
+    let mut starts = vec![0; new_index_to_old_index.len()];
+    longest_increasing_subsequence::lis_with(
+        &new_index_to_old_index,
+        &mut reverse_lis,
+        |a, b| a < b,
+        &mut predecessors,
+        &mut starts,
+    );
+
+    // Save each of the old children whose keys are reused in the new
+    // children.
+    let mut old_index_to_temp = vec![u32::MAX; old.len()];
+    let mut start = 0;
+    loop {
+        let end = (start..old.len())
+            .find(|&i| {
+                let key = old[i].key();
+                !shared_keys.contains(&key)
+            })
+            .unwrap_or(old.len());
+
+        if end - start > 0 {
+            let mut t = change_list.save_children_to_temporaries(
+                shared_prefix_count + start,
+                shared_prefix_count + end,
+            );
+            for i in start..end {
+                old_index_to_temp[i] = t;
+                t += 1;
+            }
+        }
+
+        debug_assert!(end <= old.len());
+        if end == old.len() {
+            break;
+        } else {
+            start = end + 1;
+        }
+    }
+
+    // Remove any old children whose keys were not reused in the new
+    // children. Remove from the end first so that we don't mess up indices.
+    let mut removed_count = 0;
+    for (i, old_child) in old.iter().enumerate().rev() {
+        if !shared_keys.contains(&old_child.key()) {
+            change_list.remove_child(i + shared_prefix_count);
+            removed_count += 1;
+        }
+    }
+
+    // Whether we have pushed a child onto the stack or not.
+    let mut pushed = false;
+
+    // Now iterate from the end of the new children back to the beginning,
+    // moving old children to their new destination, diffing them, and
+    // creating new children as necessary. Note that iterating in reverse
+    // order lets us use `Node.prototype.insertBefore` to move/insert
+    // children.
+    if shared_suffix_count > 0 {
+        change_list.push_child(old_shared_suffix_start - removed_count);
+        pushed = true;
+    }
+    let mut segment_end = new.len();
+    for lis_index in reverse_lis {
+        // Because we use `u32::MAX` as a sentinel value representing "a child
+        // with this key is not a member of `new`", we filter that out here.
+        let old_index = new_index_to_old_index[lis_index];
+        if old_index == u32::MAX as usize {
+            continue;
+        }
+
+        // A segment begins with a member of the LIS, which will remain in
+        // place in the DOM, followed by zero or more new children that are
+        // not members of the LIS. If one of these new children shares a key
+        // with one of the old children, then we will move that old child in
+        // the DOM. Otherwise, we create the new child afresh.
+        debug_assert!(segment_end - lis_index > 0);
+
+        // Go through each of the non-LIS child and move-and-diff or create
+        // it.
+        diff_and_move_or_create_segment(
+            cached_set,
+            change_list,
+            registry,
+            old,
+            new,
+            cached_roots,
+            lis_index + 1..segment_end,
+            &new_index_to_old_index,
+            &old_index_to_temp,
+            &mut pushed,
+        );
+
+        // Now we push the member of the LIS and diff it with its
+        // correspondingly-keyed new child.
+        let new_child = &new[lis_index];
+        let temp = old_index_to_temp[old_index];
+        debug_assert_ne!(temp, u32::MAX);
+        if pushed {
+            change_list.pop();
+        }
+        change_list.push_temporary(temp);
+        pushed = true;
+        diff(
+            cached_set,
+            change_list,
+            registry,
+            &old[old_index],
+            new_child,
+            cached_roots,
+        );
+
+        segment_end = lis_index;
+    }
+
+    // And now diff-and-move or create each of the non-LIS children that
+    // appear before the first LIS-member.
+    diff_and_move_or_create_segment(
+        cached_set,
+        change_list,
+        registry,
+        old,
+        new,
+        cached_roots,
+        0..segment_end,
+        &new_index_to_old_index,
+        &old_index_to_temp,
+        &mut pushed,
+    );
+
+    if pushed {
+        change_list.pop();
+    }
+}
+
+// Diff-and-then-move or create each new node in the given segment. The
+// segment's nodes must _not_ be members of the LIS (those nodes we will diff in
+// place elsewhere, and we should not move them nor create them afresh).
+//
+// On entering this function, the stack has the parent and optionally the next
+// sibling after this segment of children:
+//
+//     [... parent next_sibling]     if *pushed == true
+//     [... parent]                  otherwise
+//
+// After exiting, if any children were moved or created, then `pushed` is set to
+// true and the stack has the first child in this segment on top. Otherwise the
+// stack is left as it was on entering.
+//
+//     [... parent child]     if *pushed == true
+//     [... parent]           otherwise
+fn diff_and_move_or_create_segment(
+    cached_set: &CachedSet,
+    change_list: &mut ChangeListBuilder,
+    registry: &mut EventsRegistry,
+    old: &[Node],
+    new: &[Node],
+    cached_roots: &mut FxHashSet<CacheId>,
+    segment: Range<usize>,
+    new_index_to_old_index: &[usize],
+    old_index_to_temp: &[u32],
+    pushed: &mut bool,
+) {
+    for new_index in segment.rev() {
+        let new_child = &new[new_index];
+        let old_index = new_index_to_old_index[new_index];
+        if old_index == u32::MAX as usize {
+            // The key is not reused. Create this new child afresh.
+            create(cached_set, change_list, registry, new_child, cached_roots);
+        } else {
+            // The key is reused. Diff it with the old node and then
+            // move the old node into its final destination.
+            let temp = old_index_to_temp[old_index];
+            debug_assert_ne!(temp, u32::MAX);
+            change_list.push_temporary(temp);
+            diff(
+                cached_set,
+                change_list,
+                registry,
+                new_child,
+                &old[old_index],
+                cached_roots,
+            );
+        }
+
+        // At this point the stack can have one of two shapes.
+        if *pushed {
+            // [... parent next_child new_child]
+            change_list.insert_before();
+        // [... parent new_child]
+        } else {
+            // [... parent new_child]
+            change_list.append_child();
+            // [... parent]
+            change_list.push_last_child();
+            // [... parent new_child]
+            *pushed = true;
+        }
+
+        // At the end of each loop iteration, the stack looks like:
+        //
+        //     [... parent new_child]
+        debug_assert!(*pushed);
+    }
+}
+
+// Diff the suffix of keyed children that share the same keys in the same order.
+//
+// The parent must be on the stack when we enter this function:
+//
+//     [... parent]
+//
+// When this function exits, the stack remains the same.
+fn diff_keyed_suffix(
+    cached_set: &CachedSet,
+    change_list: &mut ChangeListBuilder,
+    registry: &mut EventsRegistry,
+    old: &[Node],
+    new: &[Node],
+    cached_roots: &mut FxHashSet<CacheId>,
+    new_shared_suffix_start: usize,
+) {
+    debug_assert_eq!(old.len(), new.len());
+    debug_assert!(!old.is_empty());
+
+    // [... parent]
+    change_list.push_child(new_shared_suffix_start);
+    // [... parent new_child]
+
+    for (old_child, new_child) in old.iter().zip(new.iter()) {
+        diff(
+            cached_set,
+            change_list,
+            registry,
+            old_child,
+            new_child,
+            cached_roots,
+        );
+
+        // [... parent this_new_child]
+        change_list.pop_push_next_sibling();
+        // [... parent next_new_child]
+    }
+
+    // [... parent]
+    change_list.pop();
+}
+
+// Diff children that are not keyed.
+//
+// The parent must be on the top of the stack when entering this function:
+//
+//     [... parent]
+//
+// The stack is in the same state when this function returns.
+fn diff_non_keyed_children(
+    cached_set: &CachedSet,
+    change_list: &mut ChangeListBuilder,
+    registry: &mut EventsRegistry,
+    old: &[Node],
+    new: &[Node],
+    cached_roots: &mut FxHashSet<CacheId>,
+) {
+    // Handled these cases in `diff_children` before calling this function.
+    debug_assert!(!new.is_empty());
+    debug_assert!(!old.is_empty());
+
+    for (i, (new_child, old_child)) in new.iter().zip(old.iter()).enumerate() {
+        if i == 0 {
+            change_list.push_first_child();
+        } else {
             change_list.pop_push_next_sibling();
         }
 
@@ -233,53 +775,55 @@ fn diff_children(
         );
     }
 
-    if old_children.next().is_some() {
-        debug!("  removing extra old children");
-        debug_assert!(new_children.next().is_none());
-        if pushed {
+    match old.len().cmp(&new.len()) {
+        Ordering::Greater => {
             change_list.pop_push_next_sibling();
-        } else {
-            change_list.push_first_child();
+            remove_self_and_next_siblings(change_list, registry, &old[new.len()..]);
         }
-        change_list.remove_self_and_next_siblings();
-        pushed = false;
-    } else {
-        debug!("  creating new children");
-        if pushed {
+        Ordering::Less => {
             change_list.pop();
-            pushed = false;
+            create_and_append_children(
+                cached_set,
+                change_list,
+                registry,
+                &new[old.len()..],
+                cached_roots,
+            );
         }
-        create_children(
-            cached_set,
-            change_list,
-            registry,
-            new_children,
-            cached_roots,
-        );
-    }
-
-    debug!("  done updating children");
-    if pushed {
-        change_list.pop();
+        Ordering::Equal => {
+            change_list.pop();
+        }
     }
 }
 
-fn create_children<'a, I>(
+// Create the given children and append them to the parent node.
+//
+// The parent node must currently be on top of the stack:
+//
+//     [... parent]
+//
+// When this function returns, the stack is in the same state.
+fn create_and_append_children(
     cached_set: &CachedSet,
     change_list: &mut ChangeListBuilder,
     registry: &mut EventsRegistry,
-    new: I,
+    new: &[Node],
     cached_roots: &mut FxHashSet<CacheId>,
-) where
-    I: IntoIterator<Item = &'a Node<'a>>,
-{
+) {
     for child in new {
         create(cached_set, change_list, registry, child, cached_roots);
         change_list.append_child();
     }
 }
 
-fn remove_children(
+// Remove all of a node's children.
+//
+// The stack must have this shape upon entry to this function:
+//
+//     [... parent]
+//
+// When this function returns, the stack is in the same state.
+fn remove_all_children(
     change_list: &mut ChangeListBuilder,
     registry: &mut EventsRegistry,
     old: &[Node],
@@ -292,6 +836,35 @@ fn remove_children(
     change_list.set_text("");
 }
 
+// Remove the current child and all of its following siblings.
+//
+// The stack must have this shape upon entry to this function:
+//
+//     [... parent child]
+//
+// After the function returns, the child is no longer on the stack:
+//
+//     [... parent]
+fn remove_self_and_next_siblings(
+    change_list: &mut ChangeListBuilder,
+    registry: &mut EventsRegistry,
+    old: &[Node],
+) {
+    for child in old {
+        registry.remove_subtree(child);
+    }
+    change_list.remove_self_and_next_siblings();
+}
+
+// Emit instructions to create the given virtual node.
+//
+// The stack may have any shape upon entering this function:
+//
+//     [...]
+//
+// When this function returns, the new node is on top of the stack:
+//
+//     [... node]
 fn create(
     cached_set: &CachedSet,
     change_list: &mut ChangeListBuilder,
@@ -304,6 +877,7 @@ fn create(
             change_list.create_text_node(text);
         }
         NodeKind::Element(ElementNode {
+            flags: _,
             tag_name,
             listeners,
             attributes,

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -275,6 +275,28 @@ fn diff_keyed_children(
     new: &[Node],
     cached_roots: &mut FxHashSet<CacheId>,
 ) {
+    if cfg!(debug_assertions) {
+        let mut keys = FxHashSet::default();
+        let mut assert_unique_keys = |children: &[Node]| {
+            keys.clear();
+            for child in children {
+                let key = child.key();
+                debug_assert!(
+                    key.is_some(),
+                    "if any sibling is keyed, all siblings must be keyed"
+                );
+                keys.insert(key);
+            }
+            debug_assert_eq!(
+                children.len(),
+                keys.len(),
+                "keyed siblings must each have a unique key"
+            );
+        };
+        assert_unique_keys(old);
+        assert_unique_keys(new);
+    }
+
     // First up, we diff all the nodes with the same key at the beginning of the
     // children.
     //

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -793,9 +793,13 @@ fn diff_non_keyed_children(
 
     for (i, (new_child, old_child)) in new.iter().zip(old.iter()).enumerate() {
         if i == 0 {
+            // [... parent]
             change_list.push_first_child();
+        // [... parent first_child]
         } else {
+            // [... parent prev_sibling]
             change_list.pop_push_next_sibling();
+            // [... parent next_sibling]
         }
 
         diff(
@@ -808,13 +812,23 @@ fn diff_non_keyed_children(
         );
     }
 
+    // Note that because `new` and `old` are not empty, the previous loop always
+    // executes at least once, so the change list stack is now:
+    //
+    //     [... parent child]
+
     match old.len().cmp(&new.len()) {
         Ordering::Greater => {
+            // [... parent last_shared_child]
             change_list.pop_push_next_sibling();
+            // [... parent first_child_to_remove]
             remove_self_and_next_siblings(change_list, registry, &old[new.len()..]);
+            // [... parent]
         }
         Ordering::Less => {
+            // [... parent last_child]
             change_list.pop();
+            // [... parent]
             create_and_append_children(
                 cached_set,
                 change_list,
@@ -824,7 +838,9 @@ fn diff_non_keyed_children(
             );
         }
         Ordering::Equal => {
+            // [... parent child]
             change_list.pop();
+            // [... parent]
         }
     }
 }

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -925,7 +925,7 @@ fn create(
         NodeKind::Text(TextNode { text }) => {
             change_list.create_text_node(text);
         }
-        NodeKind::Element(ElementNode {
+        NodeKind::Element(&ElementNode {
             key: _,
             tag_name,
             listeners,

--- a/src/events.rs
+++ b/src/events.rs
@@ -64,7 +64,6 @@ cfg_if::cfg_if! {
 
                 let weak_registry = Rc::downgrade(&registry);
                 let closure = Closure::wrap(Box::new(move |event, a, b| {
-                    debug!("Events trampoline invoked with (0x{:x}, 0x{:x})", a, b);
                     debug_assert!(a != 0);
 
                     // if the VdomInnerExclusive is keeping this closure alive, then the
@@ -95,7 +94,6 @@ cfg_if::cfg_if! {
 
             pub(crate) fn remove(&mut self, listener: &Listener) {
                 let id = listener.get_callback_parts();
-                debug!("EventsRegistry::remove(0x{:x}, 0x{:x})", id.0, id.1);
                 debug_assert!(id.0 != 0);
                 self.active.remove(&id);
             }
@@ -128,7 +126,6 @@ cfg_if::cfg_if! {
             /// diffing.
             pub(crate) unsafe fn add<'a>(&mut self, listener: &'a Listener<'a>) {
                 let id = listener.get_callback_parts();
-                debug!("EventsRegistry::add(0x{:x}, 0x{:x})", id.0, id.1);
                 debug_assert!(id.0 != 0);
 
                 let callback =
@@ -139,7 +136,6 @@ cfg_if::cfg_if! {
 
             /// Clear all event listeners from the registry.
             pub(crate) fn clear_active_listeners(&mut self) {
-                debug!("EventsRegistry::clear_active_listeners()");
                 self.active.clear();
             }
         }

--- a/src/node.rs
+++ b/src/node.rs
@@ -24,7 +24,7 @@ pub_unstable_internal! {
         Text(TextNode<'a>),
 
         /// An element potentially with attributes and children.
-        Element(ElementNode<'a>),
+        Element(&'a ElementNode<'a>),
 
         /// A node in the vdom's `CachedSet`. This allows us to avoid
         /// re-rendering and re-diffing subtrees.
@@ -187,15 +187,17 @@ impl<'a> Node<'a> {
         let attributes: &'a Attributes = bump.alloc(attributes);
         let attributes: &'a [Attribute<'a>] = attributes.as_ref();
 
+        let element = bump.alloc_with(|| ElementNode {
+            key,
+            tag_name,
+            listeners,
+            attributes,
+            children,
+            namespace,
+        });
+
         Node {
-            kind: NodeKind::Element(ElementNode {
-                key,
-                tag_name,
-                listeners,
-                attributes,
-                children,
-                namespace,
-            }),
+            kind: NodeKind::Element(element),
         }
     }
 

--- a/src/vdom.rs
+++ b/src/vdom.rs
@@ -277,8 +277,8 @@ impl VdomInnerExclusive {
                         &cached_set,
                         &mut change_list,
                         &mut registry,
-                        old_contents,
-                        new_contents.clone(),
+                        &old_contents,
+                        &new_contents,
                         &mut cache_roots,
                     );
 

--- a/src/vdom.rs
+++ b/src/vdom.rs
@@ -2,7 +2,7 @@ use super::change_list::ChangeListPersistentState;
 use super::RootRender;
 use crate::cached_set::CachedSet;
 use crate::events::EventsRegistry;
-use crate::node::Node;
+use crate::node::{Node, NodeKey};
 use crate::RenderContext;
 use bumpalo::Bump;
 use futures::future::Future;
@@ -166,8 +166,7 @@ impl Vdom {
 
         // Create a dummy `<div/>` in our container.
         initialize_container(container);
-        let current_root =
-            Node::element(&dom_buffers[0], Default::default(), "div", [], [], [], None);
+        let current_root = Node::element(&dom_buffers[0], NodeKey::NONE, "div", [], [], [], None);
         let current_root = Some(unsafe { extend_node_lifetime(current_root) });
 
         let container = container.clone();

--- a/src/vdom.rs
+++ b/src/vdom.rs
@@ -166,7 +166,8 @@ impl Vdom {
 
         // Create a dummy `<div/>` in our container.
         initialize_container(container);
-        let current_root = Node::element(&dom_buffers[0], "div", [], [], [], None);
+        let current_root =
+            Node::element(&dom_buffers[0], Default::default(), "div", [], [], [], None);
         let current_root = Some(unsafe { extend_node_lifetime(current_root) });
 
         let container = container.clone();
@@ -424,7 +425,6 @@ impl VdomWeak {
     /// If you don't want to do more things after the render completes, then use
     /// `schedule_render` instead of `render`.
     pub fn render(&self) -> impl Future<Item = (), Error = VdomDroppedError> {
-        debug!("VdomWeak::render: initiating render in new animation frame");
         futures::future::ok(self.inner.upgrade())
             .and_then(|inner| inner.ok_or(()))
             .map_err(|_| VdomDroppedError {})
@@ -449,7 +449,6 @@ impl VdomWeak {
                                 // animation frames.
                                 let _ = inner.shared.render_scheduled.take();
 
-                                debug!("VdomWeak::render: finished rendering");
                                 let r = resolve.call0(&JsValue::null());
                                 debug_assert!(r.is_ok());
                             }

--- a/tests/web/keyed.js
+++ b/tests/web/keyed.js
@@ -1,0 +1,25 @@
+export function saveKeyedElements(container) {
+  const saved = new Map;
+  const children = container.querySelectorAll(".keyed");
+  for (const child of children) {
+    saved.set(child.id, child);
+  }
+  return saved;
+}
+
+function assertEq(a, b, msg) {
+  if (a !== b) {
+    throw new Error(`assertEq failed: ${a} !== ${b}; ${msg}`);
+  }
+}
+
+export function checkKeyedElements(container, saved) {
+  const children = container.querySelectorAll(".keyed");
+  for (const child of children) {
+    console.log(`checking child=${child.outerHTML}`);
+    const original = saved.get(child.id);
+    if (original) {
+      assertEq(original, child, `did not preserve child with key=${child.id}`);
+    }
+  }
+}

--- a/tests/web/keyed.rs
+++ b/tests/web/keyed.rs
@@ -23,7 +23,7 @@ fn keyed<'a, Keys>(cx: &mut RenderContext<'a>, keys: Keys) -> Node<'a>
 where
     Keys: AsRef<[u16]>,
 {
-    let mut parent = div(&cx).attr("class", "parent").has_keyed_children(true);
+    let mut parent = div(&cx).attr("class", "parent");
 
     for &k in keys.as_ref() {
         parent = parent.child(Keyed(k).render(cx));
@@ -220,7 +220,6 @@ keyed_tests! {
     nested_keyed_children {
         before(cx) {
             ul(&cx)
-                .has_keyed_children(true)
                 .children([
                     li(&cx)
                         .key(1)
@@ -245,7 +244,6 @@ keyed_tests! {
         }
         after(cx) {
             ul(&cx)
-                .has_keyed_children(true)
                 .children([
                     li(&cx)
                         .key(9)

--- a/tests/web/keyed.rs
+++ b/tests/web/keyed.rs
@@ -1,0 +1,272 @@
+use crate::{assert_rendered, create_element};
+use dodrio::{builder::*, bumpalo, Node, Render, RenderContext, Vdom};
+use futures::Future;
+use log::*;
+use std::rc::Rc;
+use wasm_bindgen::prelude::*;
+use wasm_bindgen_test::*;
+
+struct Keyed(u16);
+
+impl Render for Keyed {
+    fn render<'a>(&self, cx: &mut RenderContext<'a>) -> Node<'a> {
+        let key = bumpalo::format!(in cx.bump, "{}", self.0).into_bump_str();
+        div(&cx)
+            .attr("class", "keyed")
+            .attr("id", key)
+            .key(self.0 as u32)
+            .finish()
+    }
+}
+
+fn keyed<'a, Keys>(cx: &mut RenderContext<'a>, keys: Keys) -> Node<'a>
+where
+    Keys: AsRef<[u16]>,
+{
+    let mut parent = div(&cx).attr("class", "parent").has_keyed_children(true);
+
+    for &k in keys.as_ref() {
+        parent = parent.child(Keyed(k).render(cx));
+    }
+
+    parent.finish()
+}
+
+fn assert_keyed<Before, After>(
+    before: Before,
+    after: After,
+) -> impl Future<Item = (), Error = JsValue>
+where
+    Before: 'static + Render,
+    After: 'static + Render,
+{
+    #[wasm_bindgen(module = "/tests/web/keyed.js")]
+    extern "C" {
+        #[wasm_bindgen(js_name = saveKeyedElements)]
+        fn save_keyed_elements(container: &web_sys::Element) -> JsValue;
+
+        #[wasm_bindgen(js_name = checkKeyedElements)]
+        fn check_keyed_elements(container: &web_sys::Element, saved: JsValue);
+    }
+
+    let container = create_element("div");
+
+    let before = Rc::new(before);
+    let after = Rc::new(after);
+
+    debug!("====== Rendering the *before* DOM into the physical DOM ======");
+    let vdom1 = Rc::new(Vdom::new(&container, before.clone()));
+    let vdom2 = vdom1.clone();
+    let saved = save_keyed_elements(&container);
+
+    debug!("====== Checking the *before* DOM against the physical DOM ======");
+    assert_rendered(&container, &before);
+
+    debug!("====== Rendering the *after* DOM into the physical DOM ======");
+    let weak = vdom1.weak();
+    weak.set_component(Box::new(after.clone()))
+        .map(move |_| {
+            debug!("====== Checking the *after* DOM against the physical DOM ======");
+            assert_rendered(&container, &after);
+            check_keyed_elements(&container, saved);
+            drop(vdom2);
+        })
+        .map_err(|e| JsValue::from(e.to_string()))
+}
+
+macro_rules! keyed_tests {
+    ( $(
+        $name:ident {
+            before($before_cx:ident) {
+                $( $before:tt )*
+            }
+            after($after_cx:ident) {
+                $( $after:tt )*
+            }
+        }
+    )* ) => {
+        $(
+            #[wasm_bindgen_test(async)]
+            fn $name() -> impl Future<Item = (), Error = wasm_bindgen::JsValue> {
+                use crate::RenderFn;
+                log::debug!("############### {} ###############", stringify!($name));
+                assert_keyed(
+                    RenderFn(|$before_cx| { $( $before )* }),
+                    RenderFn(|$after_cx| { $( $after )* }),
+                )
+            }
+        )*
+    }
+}
+
+keyed_tests! {
+    same_order {
+        before(cx) {
+            keyed(cx, [1, 2, 3])
+        }
+        after(cx) {
+            keyed(cx, [1, 2, 3])
+        }
+    }
+
+    same_order_append {
+        before(cx) {
+            keyed(cx, [1])
+        }
+        after(cx) {
+            keyed(cx, [1, 2])
+        }
+    }
+
+    same_order_delete {
+        before(cx) {
+            keyed(cx, [1, 2, 3])
+        }
+        after(cx) {
+            keyed(cx, [1, 2])
+        }
+    }
+
+    same_suffix {
+        before(cx) {
+            keyed(cx, [1, 2, 3])
+        }
+        after(cx) {
+            keyed(cx, [4, 2, 3])
+        }
+    }
+
+    same_prefix_and_suffix_reorder_middle {
+        before(cx) {
+            keyed(cx, [1, 2, 3, 4])
+        }
+        after(cx) {
+            keyed(cx, [1, 3, 2, 4])
+        }
+    }
+
+    same_prefix_and_suffix_new_middle {
+        before(cx) {
+            keyed(cx, [2, 3, 4, 5])
+        }
+        after(cx) {
+            keyed(cx, [2, 7, 8, 5])
+        }
+    }
+
+    reverse_order {
+        before(cx) {
+            keyed(cx, [1, 2, 3])
+        }
+        after(cx) {
+            keyed(cx, [3, 2, 1])
+        }
+    }
+
+    no_shared_keys {
+        before(cx) {
+            keyed(cx, [1, 2])
+        }
+        after(cx) {
+            keyed(cx, [3, 4])
+        }
+    }
+
+    new_keys_in_middle {
+        before(cx) {
+            keyed(cx, [1, 2])
+        }
+        after(cx) {
+            keyed(cx, [1, 3, 4, 2])
+        }
+    }
+
+    new_keys_at_start_and_end {
+        before(cx) {
+            keyed(cx, [1, 2, 3])
+        }
+        after(cx) {
+            keyed(cx, [4, 1, 2, 3, 5])
+        }
+    }
+
+    delete_prefix {
+        before(cx) {
+            keyed(cx, [1, 2, 3])
+        }
+        after(cx) {
+            keyed(cx, [2, 3])
+        }
+    }
+
+    delete_suffix {
+        before(cx) {
+            keyed(cx, [1, 2, 3])
+        }
+        after(cx) {
+            keyed(cx, [1, 2])
+        }
+    }
+
+    delete_middle {
+        before(cx) {
+            keyed(cx, [1, 2, 3])
+        }
+        after(cx) {
+            keyed(cx, [1, 3])
+        }
+    }
+
+    nested_keyed_children {
+        before(cx) {
+            ul(&cx)
+                .has_keyed_children(true)
+                .children([
+                    li(&cx)
+                        .key(1)
+                        .children([
+                            keyed(cx, [2, 3, 4])
+                        ])
+                        .finish(),
+                    li(&cx)
+                        .key(5)
+                        .children([
+                            keyed(cx, [6, 7, 8])
+                        ])
+                        .finish(),
+                    li(&cx)
+                        .key(9)
+                        .children([
+                            keyed(cx, [10, 11, 12])
+                        ])
+                        .finish(),
+                ])
+                .finish()
+        }
+        after(cx) {
+            ul(&cx)
+                .has_keyed_children(true)
+                .children([
+                    li(&cx)
+                        .key(9)
+                        .children([
+                            keyed(cx, [12, 11, 10])
+                        ])
+                        .finish(),
+                    li(&cx)
+                        .key(5)
+                        .children([
+                            keyed(cx, [8, 7, 6])
+                        ])
+                        .finish(),
+                    li(&cx)
+                        .key(1)
+                        .children([
+                            keyed(cx, [4, 3, 2])
+                        ])
+                        .finish(),
+                ])
+                .finish()
+        }
+    }
+}

--- a/tests/web/main.rs
+++ b/tests/web/main.rs
@@ -89,7 +89,7 @@ pub fn assert_rendered<R: Render>(container: &web_sys::Element, r: &R) {
                     "actual.text_content() == expected.text()"
                 );
             }
-            NodeKind::Element(ElementNode {
+            NodeKind::Element(&ElementNode {
                 tag_name,
                 attributes,
                 children,

--- a/tests/web/main.rs
+++ b/tests/web/main.rs
@@ -19,6 +19,7 @@ wasm_bindgen_test_configure!(run_in_browser);
 pub mod cached;
 pub mod events;
 pub mod js_api;
+pub mod keyed;
 pub mod render;
 
 pub fn window() -> web_sys::Window {


### PR DESCRIPTION
@alexcrichton @tschneidereit: I'd appreciate some eyes on this PR (particularly the third commit) :eyes: 

Using keyed children gives users more control over whether particular physical nodes are reused, moved, deleted, or created afresh. Specifically, if the old virtual node and the new virtual node have the same key, then the physical DOM node must be reused, and if they don't then the old physical DOM node cannot be reused.

Presumably there is some sort of CSS transition animation or third party JS that makes the virtual DOM diffing algorithm observable, or else users would let the runtime do whatever it thought was best.

This is loosely based on Inferno's keyed patching implementation. However, we have to modify the algorithm since we are compiling the diff down into change list instructions that will be executed later, rather than applying the changes to the DOM directly as we compare virtual DOMs.

https://github.com/infernojs/inferno/blob/36fd96/packages/inferno/src/DOM/patching.ts#L530-L739
