### PR TITLE
Remove css unused class from game of life example

### DIFF
--- a/examples/game-of-life/index.html
+++ b/examples/game-of-life/index.html
@@ -19,9 +19,6 @@
          padding: 0;
      }
 
-     .universe {
-     }
-
      body {
          width: 100vw;
          height: 100vh;


### PR DESCRIPTION
We add `.universe` class to main wrapper due to logical purpose, but do not use it to style this element - so we don't need empty class declaration in style.