### PR TITLE
Set `element.className = ".."` rather than call `element.setAttribute("class", "..")`

### DIFF
--- a/js/change-list-interpreter.js
+++ b/js/change-list-interpreter.js
@@ -251,6 +251,14 @@ const OP_TABLE = [
     const child = parent.childNodes[n];
     child.remove();
     return i;
+  },
+
+  // 23
+  function setClass(interpreter, mem8, mem32, i) {
+    const classId = mem32[i++];
+    const className = interpreter.getCachedString(classId);
+    top(interpreter.stack).className = className;
+    return i;
   }
 ];
 

--- a/src/change_list/emitter.rs
+++ b/src/change_list/emitter.rs
@@ -263,4 +263,13 @@ define_change_list_instructions! {
     /// child.remove()
     /// ```
     remove_child(n) = 22,
+
+    /// Stack: `[... Node] -> [... Node]`
+    ///
+    /// ```text
+    /// class = getCachedString(class)
+    /// node = stack.top()
+    /// node.className = class
+    /// ```
+    set_class(class) = 23,
 }

--- a/src/change_list/mod.rs
+++ b/src/change_list/mod.rs
@@ -229,12 +229,18 @@ impl ChangeListBuilder<'_> {
 
     pub fn set_attribute(&mut self, name: &str, value: &str) {
         debug_assert!(self.traversal_is_committed());
-        debug!("emit: set_attribute({:?}, {:?})", name, value);
-        let name_id = self.ensure_string(name);
-        let value_id = self.ensure_string(value);
-        self.state
-            .emitter
-            .set_attribute(name_id.into(), value_id.into());
+        if name == "class" {
+            let class_id = self.ensure_string(value);
+            debug!("emit: set_class({:?})", value);
+            self.state.emitter.set_class(class_id.into());
+        } else {
+            let name_id = self.ensure_string(name);
+            let value_id = self.ensure_string(value);
+            debug!("emit: set_attribute({:?}, {:?})", name, value);
+            self.state
+                .emitter
+                .set_attribute(name_id.into(), value_id.into());
+        }
     }
 
     pub fn remove_attribute(&mut self, name: &str) {


### PR DESCRIPTION
This saves around 5% of time(!) on some class-heavy benchmarks.