### PR TITLE
One line wasm_bindgen im port in examples

### DIFF
--- a/examples/moire/src/lib.rs
+++ b/examples/moire/src/lib.rs
@@ -5,8 +5,7 @@ use dodrio::{bumpalo, Node, Render, RenderContext, Vdom};
 use std::cell::RefCell;
 use std::rc::Rc;
 use std::str;
-use wasm_bindgen::prelude::*;
-use wasm_bindgen::JsCast;
+use wasm_bindgen::{prelude::*, JsCast};
 
 /// This is the main function that is automatically invoked when the wasm module
 /// is loaded.

--- a/examples/sierpinski-triangle/src/lib.rs
+++ b/examples/sierpinski-triangle/src/lib.rs
@@ -1,8 +1,7 @@
 use dodrio::{bumpalo, Node, Render, RenderContext, Vdom};
 use std::cell::RefCell;
 use std::rc::Rc;
-use wasm_bindgen::prelude::*;
-use wasm_bindgen::JsCast;
+use wasm_bindgen::{prelude::*, JsCast};
 use web_sys::Window;
 
 // Triangle container defining target size.


### PR DESCRIPTION
Import `wasm_bindgen`  elements the same one-line-way as in `game-of-life\src\lib.rs` to achieve more consistency.