### PR TITLE
Disable warning about dead code on test and bench

### DIFF
--- a/src/change_list/emitter.rs
+++ b/src/change_list/emitter.rs
@@ -30,6 +30,7 @@ impl InstructionEmitter {
 
     /// Invoke the given function with each of the allocated instruction
     /// sequences that this emitter has built up.
+    #[cfg_attr(feature = "xxx-unstable-internal-use-only", allow(dead_code))]
     pub fn each_instruction_sequence<F>(&mut self, f: F)
     where
         F: FnMut(&[u8]),


### PR DESCRIPTION
When we run `cargo test / bench` we always get warning about never used method `each_instruction_sequence` from` change_list/emitter.rs` (if not - remove `~/.cargo/registry` before run).

Behavior is correct - in our case we never invoke `self.state.emitter.each_instruction_sequence` and apply the changes to DOM.

But warning is annoying anyway, so i suggest disable it like i did.