### PR TITLE
Automatically create "templates" for `Cached<R>`

### DIFF
--- a/benches/benches.rs
+++ b/benches/benches.rs
@@ -46,9 +46,10 @@ fn criterion_benchmark(c: &mut Criterion) {
         Benchmark::new("empty", {
             let mut bump = Bump::new();
             let cached_set = RefCell::new(CachedSet::default());
+            let mut templates = Default::default();
             move |b| {
                 bump.reset();
-                let mut cx = RenderContext::new(&bump, &cached_set);
+                let mut cx = RenderContext::new(&bump, &cached_set, &mut templates);
                 b.iter(|| {
                     black_box(Empty.render(&mut cx));
                 })
@@ -63,9 +64,10 @@ fn criterion_benchmark(c: &mut Criterion) {
             {
                 let mut bump = Bump::new();
                 let cached_set = RefCell::new(CachedSet::default());
+                let mut templates = Default::default();
                 move |b, n| {
                     bump.reset();
-                    let mut cx = RenderContext::new(&bump, &cached_set);
+                    let mut cx = RenderContext::new(&bump, &cached_set, &mut templates);
                     b.iter(|| {
                         black_box(SimpleList(*n).render(&mut cx));
                     })

--- a/js/change-list-interpreter.js
+++ b/js/change-list-interpreter.js
@@ -259,6 +259,22 @@ const OP_TABLE = [
     const className = interpreter.getCachedString(classId);
     top(interpreter.stack).className = className;
     return i;
+  },
+
+  // 24
+  function saveTemplate(interpreter, mem8, mem32, i) {
+    const id = mem32[i++];
+    const template = top(interpreter.stack);
+    interpreter.saveTemplate(id, template.cloneNode(true));
+    return i;
+  },
+
+  // 25
+  function pushTemplate(interpreter, mem8, mem32, i) {
+    const id = mem32[i++];
+    const template = interpreter.getTemplate(id);
+    interpreter.stack.push(template.cloneNode(true));
+    return i;
   }
 ];
 
@@ -270,6 +286,7 @@ export class ChangeListInterpreter {
     this.stack = [];
     this.strings = new Map();
     this.temporaries = [];
+    this.templates = new Map();
   }
 
   unmount() {
@@ -283,6 +300,7 @@ export class ChangeListInterpreter {
     this.stack = null;
     this.strings = null;
     this.temporaries = null;
+    this.templates = null;
   }
 
   addChangeListRange(start, len) {
@@ -328,6 +346,14 @@ export class ChangeListInterpreter {
 
   getCachedString(id) {
     return this.strings.get(id);
+  }
+
+  saveTemplate(id, template) {
+    this.templates.set(id, template);
+  }
+
+  getTemplate(id) {
+    return this.templates.get(id);
   }
 
   initEventsTrampoline(trampoline) {

--- a/js/strace.js
+++ b/js/strace.js
@@ -6,9 +6,13 @@ export function initStrace() {
 }
 
 const counts = new Map;
+counts.total = 0;
+
 let timer = null;
 
 function log(ctorName, kind, key) {
+  counts.total += 1;
+
   const entry = `${kind} ${ctorName}#${key}`
   const count = counts.get(entry);
   if (count === undefined) {
@@ -27,8 +31,13 @@ function dumpAndReset() {
   const data = [...counts]
         .sort((a, b) => b[1] - a[1])
         .map(a => ({ "DOM Method": a[0], "Count": a[1] }));
+
+  data.push({ "DOM Method": "<total>", "Count": counts.total });
+
   console.table(data, ["DOM Method", "Count"]);
+
   counts.clear();
+  counts.total = 0;
 }
 
 function instrument(proto, key, desc) {

--- a/src/change_list/emitter.rs
+++ b/src/change_list/emitter.rs
@@ -272,4 +272,20 @@ define_change_list_instructions! {
     /// node.className = class
     /// ```
     set_class(class) = 23,
+
+    /// Stack: `[... Node] -> [... Node]`
+    ///
+    /// ```text
+    /// template = stack.top()
+    /// saveTemplate(id, template)
+    /// ```
+    save_template(id) = 24,
+
+    /// Stack: `[...] -> [... Node]`
+    ///
+    /// ```text
+    /// template = getTemplate(id)
+    /// stack.push(template.cloneNode(true))
+    /// ```
+    push_template(id) = 25,
 }

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -98,9 +98,27 @@ pub(crate) fn diff(
                 return;
             }
 
-            let new = cached_set.get(new.id);
-            let old = cached_set.get(old.id);
-            diff(cached_set, change_list, registry, old, new, cached_roots);
+            let (new, new_template) = cached_set.get(new.id);
+            let (old, old_template) = cached_set.get(old.id);
+            if new_template == old_template {
+                // If they are both using the same template, then just diff the
+                // subtrees.
+                diff(cached_set, change_list, registry, old, new, cached_roots);
+            } else {
+                // Otherwise, they are probably different enough that
+                // re-constructing the subtree from scratch should be faster.
+                // This doubly holds true if we have a new template.
+                change_list.commit_traversal();
+                create_and_replace(
+                    cached_set,
+                    change_list,
+                    registry,
+                    new_template,
+                    old,
+                    new,
+                    cached_roots,
+                );
+            }
         }
 
         // New cached node when the old node was not cached. In this scenario,
@@ -109,10 +127,16 @@ pub(crate) fn diff(
         (&NodeKind::Cached(ref c), _) => {
             change_list.commit_traversal();
             cached_roots.insert(c.id);
-            let new = cached_set.get(c.id);
-            create(cached_set, change_list, registry, new, cached_roots);
-            registry.remove_subtree(&old);
-            change_list.replace_with();
+            let (new, new_template) = cached_set.get(c.id);
+            create_and_replace(
+                cached_set,
+                change_list,
+                registry,
+                new_template,
+                old,
+                new,
+                cached_roots,
+            );
         }
 
         // Old cached node and new non-cached node. Again, assume that they are
@@ -237,6 +261,35 @@ fn diff_children(
             remove_all_children(change_list, registry, old);
         }
         return;
+    }
+
+    if new.len() == 1 {
+        match (old.first(), &new[0]) {
+            (
+                Some(&Node {
+                    kind: NodeKind::Text(TextNode { text: old_text }),
+                }),
+                &Node {
+                    kind: NodeKind::Text(TextNode { text: new_text }),
+                },
+            ) if old_text == new_text => {
+                // Don't take this fast path...
+            }
+            (
+                _,
+                &Node {
+                    kind: NodeKind::Text(TextNode { text }),
+                },
+            ) => {
+                change_list.commit_traversal();
+                change_list.set_text(text);
+                for o in old {
+                    registry.remove_subtree(o);
+                }
+                return;
+            }
+            (_, _) => {}
+        }
     }
 
     if old.is_empty() {
@@ -926,8 +979,147 @@ fn create(
         }
         NodeKind::Cached(ref c) => {
             cached_roots.insert(c.id);
-            let node = cached_set.get(c.id);
-            create(cached_set, change_list, registry, node, cached_roots)
+            let (node, template) = cached_set.get(c.id);
+            if let Some(template) = template {
+                create_with_template(
+                    cached_set,
+                    change_list,
+                    registry,
+                    template,
+                    node,
+                    cached_roots,
+                );
+            } else {
+                create(cached_set, change_list, registry, node, cached_roots);
+            }
         }
     }
+}
+
+// Get or create the template.
+//
+// Upon entering this function the change list stack may be in any shape:
+//
+//     [...]
+//
+// When this function returns, it leaves a freshly cloned copy of the template
+// on the top of the change list stack:
+//
+//     [... template]
+#[inline]
+fn get_or_create_template<'a>(
+    cached_set: &'a CachedSet,
+    change_list: &mut ChangeListBuilder,
+    registry: &mut EventsRegistry,
+    cached_roots: &mut FxHashSet<CacheId>,
+    template_id: CacheId,
+) -> (&'a Node<'a>, bool) {
+    let (template, template_template) = cached_set.get(template_id);
+    debug_assert!(
+        template_template.is_none(),
+        "templates should not be templated themselves"
+    );
+
+    // If we haven't already created and saved the physical DOM subtree for this
+    // template, do that now.
+    if change_list.has_template(template_id) {
+        // Clone the template and push it onto the stack.
+        //
+        // [...]
+        change_list.push_template(template_id);
+        // [... template]
+
+        (template, true)
+    } else {
+        // [...]
+        create(cached_set, change_list, registry, template, cached_roots);
+        // [... template]
+        change_list.save_template(template_id);
+        // [... template]
+
+        (template, false)
+    }
+}
+
+fn create_and_replace(
+    cached_set: &CachedSet,
+    change_list: &mut ChangeListBuilder,
+    registry: &mut EventsRegistry,
+    new_template: Option<CacheId>,
+    old: &Node,
+    new: &Node,
+    cached_roots: &mut FxHashSet<CacheId>,
+) {
+    debug_assert!(change_list.traversal_is_committed());
+
+    if let Some(template_id) = new_template {
+        let (template, needs_listeners) =
+            get_or_create_template(cached_set, change_list, registry, cached_roots, template_id);
+        change_list.replace_with();
+
+        let mut old_forcing = None;
+        if needs_listeners {
+            old_forcing = Some(change_list.push_force_new_listeners());
+        }
+
+        diff(
+            cached_set,
+            change_list,
+            registry,
+            template,
+            new,
+            cached_roots,
+        );
+
+        if let Some(old) = old_forcing {
+            change_list.pop_force_new_listeners(old);
+        }
+
+        change_list.commit_traversal();
+    } else {
+        create(cached_set, change_list, registry, new, cached_roots);
+        change_list.replace_with();
+    }
+    registry.remove_subtree(old);
+}
+
+fn create_with_template(
+    cached_set: &CachedSet,
+    change_list: &mut ChangeListBuilder,
+    registry: &mut EventsRegistry,
+    template_id: CacheId,
+    node: &Node,
+    cached_roots: &mut FxHashSet<CacheId>,
+) {
+    debug_assert!(change_list.traversal_is_committed());
+
+    // [...]
+    let (template, needs_listeners) =
+        get_or_create_template(cached_set, change_list, registry, cached_roots, template_id);
+    // [... template]
+
+    // Now diff the node with its template.
+    //
+    // We must force adding new listeners instead of updating existing ones,
+    // since listeners don't get cloned in `cloneNode`.
+    let mut old_forcing = None;
+    if needs_listeners {
+        old_forcing = Some(change_list.push_force_new_listeners());
+    }
+
+    diff(
+        cached_set,
+        change_list,
+        registry,
+        template,
+        node,
+        cached_roots,
+    );
+
+    if let Some(old) = old_forcing {
+        change_list.pop_force_new_listeners(old);
+    }
+
+    // Make sure that we come back up to the level we were at originally.
+    change_list.commit_traversal();
 }

--- a/src/render_context.rs
+++ b/src/render_context.rs
@@ -1,5 +1,10 @@
-use crate::cached_set::CachedSet;
+use crate::{
+    cached::{Cached, TemplateId},
+    cached_set::{CacheId, CachedSet},
+    Node, Render,
+};
 use bumpalo::Bump;
+use fxhash::FxHashMap;
 use std::fmt;
 
 /// Common context available to all `Render` implementations.
@@ -23,6 +28,8 @@ pub struct RenderContext<'a> {
 
     pub(crate) cached_set: &'a crate::RefCell<CachedSet>,
 
+    pub(crate) templates: &'a mut FxHashMap<TemplateId, Option<CacheId>>,
+
     // Prevent exhaustive matching on the rendering context, so we can always
     // add more members in a semver-compatible way.
     _non_exhaustive: (),
@@ -38,13 +45,47 @@ impl fmt::Debug for RenderContext<'_> {
 
 impl<'a> RenderContext<'a> {
     pub_unstable_internal! {
-        pub(crate) fn new(bump: &'a Bump, cached_set: &'a crate::RefCell<CachedSet>) -> Self {
+        pub(crate) fn new(
+            bump: &'a Bump,
+            cached_set: &'a crate::RefCell<CachedSet>,
+            templates: &'a mut FxHashMap<TemplateId, Option<CacheId>>
+        ) -> Self {
             RenderContext {
                 bump,
                 cached_set,
+                templates,
                 _non_exhaustive: (),
             }
         }
+    }
+
+    pub(crate) fn cache<F>(&mut self, pinned: bool, template: Option<CacheId>, f: F) -> CacheId
+    where
+        F: for<'b> FnOnce(&mut RenderContext<'b>) -> Node<'b>,
+    {
+        CachedSet::insert(self, pinned, template, f)
+    }
+
+    /// Get or create the cached template for `Cached<R>`.
+    pub(crate) fn template<R>(&mut self) -> Option<CacheId>
+    where
+        R: 'static + Default + Render,
+    {
+        let template_id = Cached::<R>::template_id();
+        if let Some(cache_id) = self.templates.get(&template_id).cloned() {
+            return cache_id;
+        }
+
+        // Prevent re-entrancy from infinite looping. Any attempts to get `R`'s
+        // template while constructing the template will simply fail to use the
+        // templated fast path.
+        self.templates.insert(template_id, None);
+
+        // Render the default `R` and save that as the template for all
+        // `Cached<R>`s.
+        let cache_id = self.cache(true, None, |nested_cx| R::default().render(nested_cx));
+        self.templates.insert(template_id, Some(cache_id));
+        Some(cache_id)
     }
 }
 

--- a/src/vdom.rs
+++ b/src/vdom.rs
@@ -1,11 +1,13 @@
 use super::change_list::ChangeListPersistentState;
 use super::RootRender;
-use crate::cached_set::CachedSet;
+use crate::cached::TemplateId;
+use crate::cached_set::{CacheId, CachedSet};
 use crate::events::EventsRegistry;
 use crate::node::{Node, NodeKey};
 use crate::RenderContext;
 use bumpalo::Bump;
 use futures::future::Future;
+use fxhash::FxHashMap;
 use std::cell::Cell;
 use std::cell::RefCell;
 use std::fmt;
@@ -61,6 +63,7 @@ pub(crate) struct VdomInnerExclusive {
     events_registry: Option<Rc<RefCell<EventsRegistry>>>,
     events_trampoline: Option<crate::EventsTrampoline>,
     cached_set: crate::RefCell<CachedSet>,
+    templates: FxHashMap<TemplateId, Option<CacheId>>,
 
     // Actually a reference into `self.dom_buffers[0]` or if `self.component` is
     // caching renders, into `self.component`'s bump.
@@ -186,6 +189,7 @@ impl Vdom {
                 events_registry: None,
                 events_trampoline: None,
                 cached_set: crate::RefCell::new(Default::default()),
+                templates: Default::default(),
             }),
         });
 
@@ -265,7 +269,8 @@ impl VdomInnerExclusive {
                 dom_buffers[1].reset();
 
                 // Render the new current contents into the inactive bump arena.
-                let mut cx = RenderContext::new(&dom_buffers[1], &self.cached_set);
+                let mut cx =
+                    RenderContext::new(&dom_buffers[1], &self.cached_set, &mut self.templates);
                 let new_contents = self.component.as_ref().unwrap_throw().render(&mut cx);
                 let new_contents = extend_node_lifetime(new_contents);
 

--- a/tests/web/cached.js
+++ b/tests/web/cached.js
@@ -1,0 +1,11 @@
+let cloneNodeCount = 0;
+
+const origCloneNode = Node.prototype.cloneNode;
+Node.prototype.cloneNode = function (...args) {
+  cloneNodeCount += 1;
+  return origCloneNode.apply(this, args);
+};
+
+export function getCloneNodeCount() {
+  return cloneNodeCount;
+}

--- a/tests/web/main.rs
+++ b/tests/web/main.rs
@@ -7,6 +7,7 @@ use dodrio::{
     Attribute, CachedSet, ElementNode, Node, NodeKind, Render, RenderContext, TextNode, Vdom,
 };
 use futures::prelude::*;
+use fxhash::FxHashMap;
 use log::*;
 use std::cell::RefCell;
 use std::rc::Rc;
@@ -55,7 +56,8 @@ pub fn assert_rendered<R: Render>(container: &web_sys::Element, r: &R) {
 
     let cached_set = &RefCell::new(CachedSet::default());
     let bump = &Bump::new();
-    let cx = &mut RenderContext::new(bump, cached_set);
+    let templates = &mut FxHashMap::default();
+    let cx = &mut RenderContext::new(bump, cached_set, templates);
     let node = r.render(cx);
     let child = container
         .first_child()
@@ -111,7 +113,7 @@ pub fn assert_rendered<R: Render>(container: &web_sys::Element, r: &R) {
                 }
             }
             NodeKind::Cached(ref c) => {
-                let expected = cached_set.get(c.id);
+                let (expected, _template) = cached_set.get(c.id);
                 check_node(cached_set, actual, &expected);
             }
         }


### PR DESCRIPTION
This adds a `R: Default` trait bound to `Cached<R>`, and the first time any instance of `Cached<R>` is rendered, we first render the default `R` instance and save it as a "template" for all future `Cached<R>` renders. The subsequent renders will call `cloneNode` (with the "deep" parameter set to true) on the template and then diff against the cloned node, rather than creating the whole subtree from scratch. This cuts down on DOM method invocations and traversal instructions.