### PR TITLE
Remove empty tests from render.rs

### DIFF
--- a/src/render.rs
+++ b/src/render.rs
@@ -124,18 +124,3 @@ impl dyn RootRender {
             .expect_throw("bad `RootRender::unwrap_ref` call")
     }
 }
-
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn render_is_object_safe() {
-        #[allow(dead_code)]
-        fn takes_dyn_render(_: &dyn super::Render) {}
-    }
-
-    #[test]
-    fn root_render_is_object_safe() {
-        #[allow(dead_code)]
-        fn takes_dyn_render(_: &dyn super::RootRender) {}
-    }
-}


### PR DESCRIPTION
In `render.rs` file we have test module with 2 "empty" test functions with `allow(dead_code)` lint attribute.
I have noticed in history of this file, that this always look like that (no `//TODO` comment or something).

Also in `/tests/web/render.rs` we have some test connected to render process.

So my question is - can we delete it like i did in this PR, or rather we should implement this tests cases ?