### PR TITLE
CI: Temporarily stop running headless tests in Chrome

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,11 +33,6 @@ matrix:
       addons:
         firefox: latest
       script: wasm-pack test --firefox --headless -- --features xxx-unstable-internal-use-only
-    - name: "headless browser tests (chrome)"
-      rust: stable
-      addons:
-        chrome: stable
-      script: wasm-pack test --chrome --headless -- --features xxx-unstable-internal-use-only
     - name: "native tests"
       rust: stable
       install: echo "no install"
@@ -46,3 +41,10 @@ matrix:
       rust: nightly
       install: echo "no install"
       script: cargo check --benches --features xxx-unstable-internal-use-only
+    # TODO: `chromedriver` is complaining about ports or something. Temporarily
+    # disable in CI until we figure it out.
+    # - name: "headless browser tests (chrome)"
+    #   rust: stable
+    #   addons:
+    #     chrome: stable
+    #   script: wasm-pack test --chrome --headless -- --features xxx-unstable-internal-use-only


### PR DESCRIPTION
`chromedriver` is complaining about ports or something. We still run them in Firefox in the meantime.