### PR TITLE
Bump-Scoped rendering and SVG class attribute fix

### DIFF
--- a/benches/benches.rs
+++ b/benches/benches.rs
@@ -17,16 +17,16 @@ use std::convert::TryInto;
 
 /// The simplest thing we can render: `<div/>`.
 struct Empty;
-impl Render for Empty {
-    fn render<'a>(&self, cx: &mut RenderContext<'a>) -> Node<'a> {
+impl<'a> Render<'a> for Empty {
+    fn render(&self, cx: &mut RenderContext<'a>) -> Node<'a> {
         div(&cx).finish()
     }
 }
 
 /// Render a list that is `self.0` items long, has attributes and listeners.
 struct SimpleList(usize);
-impl Render for SimpleList {
-    fn render<'a>(&self, cx: &mut RenderContext<'a>) -> Node<'a> {
+impl<'a> Render<'a> for SimpleList {
+    fn render(&self, cx: &mut RenderContext<'a>) -> Node<'a> {
         let mut children = bumpalo::collections::Vec::with_capacity_in(self.0, cx.bump);
         children.extend((0..self.0).map(|_| {
             li(&cx)

--- a/crates/js-api/src/lib.rs
+++ b/crates/js-api/src/lib.rs
@@ -216,8 +216,8 @@ impl JsRender {
     }
 }
 
-impl Render for JsRender {
-    fn render<'a>(&self, cx: &mut RenderContext<'a>) -> Node<'a> {
+impl<'a> Render<'a> for JsRender {
+    fn render(&self, cx: &mut RenderContext<'a>) -> Node<'a> {
         create(cx, self.render())
     }
 }

--- a/crates/js-api/src/lib.rs
+++ b/crates/js-api/src/lib.rs
@@ -99,8 +99,8 @@ impl GreetingViaJs {
 
 /// And finally the `Render` implementation! This adds a `<p>` element and some
 /// text around whatever the inner JS `Greeting` component renders.
-impl Render for GreetingViaJs {
-    fn render<'a>(&self, cx: &mut RenderContext<'a>) -> Node<'a> {
+impl<'a> Render<'a> for GreetingViaJs {
+    fn render(&self, cx: &mut RenderContext<'a>) -> Node<'a> {
         use dodrio::builder::*;
         p(&cx)
             .children([

--- a/examples/counter/src/lib.rs
+++ b/examples/counter/src/lib.rs
@@ -26,8 +26,8 @@ impl Counter {
 
 // The `Render` implementation for `Counter`s displays the current count and has
 // buttons to increment and decrement the count.
-impl Render for Counter {
-    fn render<'a>(&self, cx: &mut RenderContext<'a>) -> Node<'a> {
+impl<'a> Render<'a> for Counter {
+    fn render(&self, cx: &mut RenderContext<'a>) -> Node<'a> {
         use dodrio::builder::*;
 
         // Stringify the count as a bump-allocated string.

--- a/examples/game-of-life/src/lib.rs
+++ b/examples/game-of-life/src/lib.rs
@@ -126,8 +126,8 @@ impl Universe {
 }
 
 /// The rendering implementation for our Game of Life.
-impl Render for Universe {
-    fn render<'a>(&self, cx: &mut RenderContext<'a>) -> Node<'a> {
+impl<'a> Render<'a> for Universe {
+    fn render(&self, cx: &mut RenderContext<'a>) -> Node<'a> {
         use dodrio::builder::*;
 
         let mut rows = bumpalo::collections::Vec::with_capacity_in(self.height as usize, cx.bump);

--- a/examples/hello-world/src/lib.rs
+++ b/examples/hello-world/src/lib.rs
@@ -10,8 +10,8 @@ struct Hello {
 
 // The `Render` implementation describes how to render a `Hello` component into
 // HTML.
-impl Render for Hello {
-    fn render<'a>(&self, cx: &mut RenderContext<'a>) -> Node<'a> {
+impl<'a> Render<'a> for Hello {
+    fn render(&self, cx: &mut RenderContext<'a>) -> Node<'a> {
         let msg = bumpalo::format!(in cx.bump, "Hello, {}!", self.who);
         let msg = msg.into_bump_str();
         p(&cx).children([text(msg)]).finish()

--- a/examples/input-form/src/lib.rs
+++ b/examples/input-form/src/lib.rs
@@ -23,8 +23,8 @@ impl SayHelloTo {
 
 // The `Render` implementation has a text `<input>` and a `<div>` that shows a
 // greeting to the `<input>`'s value.
-impl Render for SayHelloTo {
-    fn render<'a>(&self, cx: &mut RenderContext<'a>) -> Node<'a> {
+impl<'a> Render<'a> for SayHelloTo {
+    fn render(&self, cx: &mut RenderContext<'a>) -> Node<'a> {
         use dodrio::builder::*;
 
         div(&cx)

--- a/examples/js-component/src/lib.rs
+++ b/examples/js-component/src/lib.rs
@@ -31,8 +31,8 @@ impl GreetingViaJs {
 
 /// Here's the `Render` implementation! This adds a `<p>` element and some text
 /// around whatever the inner JS `Greeting` component renders.
-impl Render for GreetingViaJs {
-    fn render<'a>(&self, cx: &mut RenderContext<'a>) -> Node<'a> {
+impl<'a> Render<'a> for GreetingViaJs {
+    fn render(&self, cx: &mut RenderContext<'a>) -> Node<'a> {
         use dodrio::builder::*;
         p(&cx)
             .children([text("JavaScript says: "), self.js.render(cx)])

--- a/examples/moire/src/lib.rs
+++ b/examples/moire/src/lib.rs
@@ -104,8 +104,8 @@ impl Moire {
     }
 }
 
-impl Render for Moire {
-    fn render<'a>(&self, cx: &mut RenderContext<'a>) -> Node<'a> {
+impl<'a> Render<'a> for Moire {
+    fn render(&self, cx: &mut RenderContext<'a>) -> Node<'a> {
         use dodrio::builder::*;
 
         let elapsed = web_sys::window()

--- a/examples/sierpinski-triangle/src/lib.rs
+++ b/examples/sierpinski-triangle/src/lib.rs
@@ -85,8 +85,8 @@ impl Container {
     }
 }
 
-impl Render for Container {
-    fn render<'a>(&self, cx: &mut RenderContext<'a>) -> Node<'a> {
+impl<'a> Render<'a> for Container {
+    fn render(&self, cx: &mut RenderContext<'a>) -> Node<'a> {
         use dodrio::builder::div;
 
         let elapsed = web_sys::window()

--- a/examples/todomvc/src/todo.rs
+++ b/examples/todomvc/src/todo.rs
@@ -116,8 +116,8 @@ impl<C> Todo<C> {
     }
 }
 
-impl<C: TodoActions> Render for Todo<C> {
-    fn render<'a>(&self, cx: &mut RenderContext<'a>) -> Node<'a> {
+impl<'a, C: TodoActions> Render<'a> for Todo<C> {
+    fn render(&self, cx: &mut RenderContext<'a>) -> Node<'a> {
         use dodrio::{
             builder::*,
             bumpalo::{self, collections::String},

--- a/examples/todomvc/src/todos.rs
+++ b/examples/todomvc/src/todos.rs
@@ -289,8 +289,8 @@ impl<C: TodosActions> Todos<C> {
     }
 }
 
-impl<C: TodosActions> Render for Todos<C> {
-    fn render<'a>(&self, cx: &mut RenderContext<'a>) -> Node<'a> {
+impl<'a, C: TodosActions> Render<'a> for Todos<C> {
+    fn render(&self, cx: &mut RenderContext<'a>) -> Node<'a> {
         use dodrio::builder::*;
 
         div(&cx)

--- a/src/cached.rs
+++ b/src/cached.rs
@@ -45,8 +45,8 @@ where
     ///     count: u32,
     /// }
     ///
-    /// impl Render for Counter {
-    ///     fn render<'a>(&self, cx: &mut RenderContext<'a>) -> Node<'a> {
+    /// impl<'a> Render<'a> for Counter {
+    ///     fn render(&self, cx: &mut RenderContext<'a>) -> Node<'a> {
     ///         // ...
     /// #       unimplemented!()
     ///     }
@@ -85,8 +85,8 @@ where
     ///     who: String
     /// }
     ///
-    /// impl Render for Hello {
-    ///     fn render<'a>(&self, cx: &mut RenderContext<'a>) -> Node<'a> {
+    /// impl<'a> Render<'a> for Hello {
+    ///     fn render(&self, cx: &mut RenderContext<'a>) -> Node<'a> {
     ///         use dodrio::builder::*;
     ///         let greeting = bumpalo::format!(in cx.bump, "Hello, {}!", self.who);
     ///         p(&cx)
@@ -143,11 +143,11 @@ where
     }
 }
 
-impl<R> Render for Cached<R>
+impl<'a, R> Render<'a> for Cached<R>
 where
-    R: 'static + Default + Render,
+    R: 'static + Default + for<'b> Render<'b>,
 {
-    fn render<'a>(&self, cx: &mut RenderContext<'a>) -> Node<'a> {
+    fn render(&self, cx: &mut RenderContext<'a>) -> Node<'a> {
         let template = cx.template::<R>();
         let cached = match self.cached.get() {
             // This does-the-cache-contain-this-id check is necessary because

--- a/src/change_list/emitter.rs
+++ b/src/change_list/emitter.rs
@@ -272,7 +272,7 @@ define_change_list_instructions! {
     /// node = stack.top()
     /// node.className = class
     /// ```
-    //set_class(class) = 23,
+    set_class(class) = 23,
 
     /// Stack: `[... Node] -> [... Node]`
     ///

--- a/src/change_list/emitter.rs
+++ b/src/change_list/emitter.rs
@@ -272,7 +272,7 @@ define_change_list_instructions! {
     /// node = stack.top()
     /// node.className = class
     /// ```
-    set_class(class) = 23,
+    //set_class(class) = 23,
 
     /// Stack: `[... Node] -> [... Node]`
     ///

--- a/src/change_list/mod.rs
+++ b/src/change_list/mod.rs
@@ -233,20 +233,20 @@ impl ChangeListBuilder<'_> {
         self.state.emitter.replace_with();
     }
 
-    pub fn set_attribute(&mut self, name: &str, value: &str) {
+    pub fn set_attribute(&mut self, name: &str, value: &str, is_namespaced: bool) {
         debug_assert!(self.traversal_is_committed());
-        // if name == "class" {
-        //     let class_id = self.ensure_string(value);
-        //     debug!("emit: set_class({:?})", value);
-        //     self.state.emitter.set_class(class_id.into());
-        // } else {
-        let name_id = self.ensure_string(name);
-        let value_id = self.ensure_string(value);
-        debug!("emit: set_attribute({:?}, {:?})", name, value);
-        self.state
-            .emitter
-            .set_attribute(name_id.into(), value_id.into());
-        // }
+        if name == "class" && !is_namespaced {
+            let class_id = self.ensure_string(value);
+            debug!("emit: set_class({:?})", value);
+            self.state.emitter.set_class(class_id.into());
+        } else {
+            let name_id = self.ensure_string(name);
+            let value_id = self.ensure_string(value);
+            debug!("emit: set_attribute({:?}, {:?})", name, value);
+            self.state
+                .emitter
+                .set_attribute(name_id.into(), value_id.into());
+        }
     }
 
     pub fn remove_attribute(&mut self, name: &str) {

--- a/src/change_list/mod.rs
+++ b/src/change_list/mod.rs
@@ -240,12 +240,12 @@ impl ChangeListBuilder<'_> {
         //     debug!("emit: set_class({:?})", value);
         //     self.state.emitter.set_class(class_id.into());
         // } else {
-            let name_id = self.ensure_string(name);
-            let value_id = self.ensure_string(value);
-            debug!("emit: set_attribute({:?}, {:?})", name, value);
-            self.state
-                .emitter
-                .set_attribute(name_id.into(), value_id.into());
+        let name_id = self.ensure_string(name);
+        let value_id = self.ensure_string(value);
+        debug!("emit: set_attribute({:?}, {:?})", name, value);
+        self.state
+            .emitter
+            .set_attribute(name_id.into(), value_id.into());
         // }
     }
 

--- a/src/change_list/mod.rs
+++ b/src/change_list/mod.rs
@@ -235,18 +235,18 @@ impl ChangeListBuilder<'_> {
 
     pub fn set_attribute(&mut self, name: &str, value: &str) {
         debug_assert!(self.traversal_is_committed());
-        if name == "class" {
-            let class_id = self.ensure_string(value);
-            debug!("emit: set_class({:?})", value);
-            self.state.emitter.set_class(class_id.into());
-        } else {
+        // if name == "class" {
+        //     let class_id = self.ensure_string(value);
+        //     debug!("emit: set_class({:?})", value);
+        //     self.state.emitter.set_class(class_id.into());
+        // } else {
             let name_id = self.ensure_string(name);
             let value_id = self.ensure_string(value);
             debug!("emit: set_attribute({:?}, {:?})", name, value);
             self.state
                 .emitter
                 .set_attribute(name_id.into(), value_id.into());
-        }
+        // }
     }
 
     pub fn remove_attribute(&mut self, name: &str) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,8 +18,8 @@
 //!     }
 //! }
 //!
-//! impl<'who> Render for Hello<'who> {
-//!     fn render<'a>(&self, cx: &mut RenderContext<'a>) -> Node<'a> {
+//! impl<'a, 'who> Render<'a> for Hello<'who> {
+//!     fn render(&self, cx: &mut RenderContext<'a>) -> Node<'a> {
 //!         use dodrio::builder::*;
 //!
 //!         let id = bumpalo::format!(in cx.bump, "hello-{}", self.who);

--- a/src/render.rs
+++ b/src/render.rs
@@ -148,7 +148,7 @@ mod tests {
         }
 
         impl<'a> Render<'a> for Child<'a> {
-            fn render(&self, cx: &mut RenderContext<'a>) -> Node<'a> {
+            fn render(&self, _cx: &mut RenderContext<'a>) -> Node<'a> {
                 text(self.name)
             }
         }

--- a/src/render.rs
+++ b/src/render.rs
@@ -141,8 +141,8 @@ mod tests {
 
     #[test]
     fn render_bump_scoped_child() {
-        use crate::{Node, Render, bumpalo::collections::String, RenderContext, builder::*};
-        
+        use crate::{builder::*, bumpalo::collections::String, Node, Render, RenderContext};
+
         struct Child<'a> {
             name: &'a str,
         }
@@ -159,7 +159,9 @@ mod tests {
             fn render(&self, cx: &mut RenderContext<'a>) -> Node<'a> {
                 let child_name = String::from_str_in("child", cx.bump).into_bump_str();
 
-                div(&cx).children([Child { name: child_name }.render(cx)]).finish()
+                div(&cx)
+                    .children([Child { name: child_name }.render(cx)])
+                    .finish()
             }
         }
     }

--- a/src/render_context.rs
+++ b/src/render_context.rs
@@ -69,7 +69,7 @@ impl<'a> RenderContext<'a> {
     /// Get or create the cached template for `Cached<R>`.
     pub(crate) fn template<R>(&mut self) -> Option<CacheId>
     where
-        R: 'static + Default + Render,
+        R: 'static + Default + for<'b> Render<'b>,
     {
         let template_id = Cached::<R>::template_id();
         if let Some(cache_id) = self.templates.get(&template_id).cloned() {

--- a/tests/web/cached.rs
+++ b/tests/web/cached.rs
@@ -18,8 +18,8 @@ impl CountRenders {
     }
 }
 
-impl Render for CountRenders {
-    fn render<'a>(&self, cx: &mut RenderContext<'a>) -> Node<'a> {
+impl<'a> Render<'a> for CountRenders {
+    fn render(&self, cx: &mut RenderContext<'a>) -> Node<'a> {
         let count = self.render_count.get() + 1;
         self.render_count.set(count);
 
@@ -153,8 +153,8 @@ impl Default for Id {
     }
 }
 
-impl Render for Id {
-    fn render<'a>(&self, _cx: &mut RenderContext<'a>) -> Node<'a> {
+impl<'a> Render<'a> for Id {
+    fn render(&self, _cx: &mut RenderContext<'a>) -> Node<'a> {
         text(self.0)
     }
 }

--- a/tests/web/events.rs
+++ b/tests/web/events.rs
@@ -24,8 +24,8 @@ impl EventContainer {
     }
 }
 
-impl Render for EventContainer {
-    fn render<'a>(&self, cx: &mut RenderContext<'a>) -> Node<'a> {
+impl<'a> Render<'a> for EventContainer {
+    fn render(&self, cx: &mut RenderContext<'a>) -> Node<'a> {
         use dodrio::builder::*;
         div(&cx)
             .attr("id", "target")
@@ -126,8 +126,8 @@ impl ListensOnlyOnFirstRender {
     }
 }
 
-impl Render for ListensOnlyOnFirstRender {
-    fn render<'a>(&self, cx: &mut RenderContext<'a>) -> Node<'a> {
+impl<'a> Render<'a> for ListensOnlyOnFirstRender {
+    fn render(&self, cx: &mut RenderContext<'a>) -> Node<'a> {
         use dodrio::builder::*;
 
         let count = self.count.get();

--- a/tests/web/js_api.rs
+++ b/tests/web/js_api.rs
@@ -35,8 +35,8 @@ impl WrapJs {
     }
 }
 
-impl Render for WrapJs {
-    fn render<'a>(&self, cx: &mut RenderContext<'a>) -> Node<'a> {
+impl<'a> Render<'a> for WrapJs {
+    fn render(&self, cx: &mut RenderContext<'a>) -> Node<'a> {
         div(&cx)
             .attr("class", "wrap-js")
             .children([self.inner.render(cx)])

--- a/tests/web/keyed.rs
+++ b/tests/web/keyed.rs
@@ -7,8 +7,8 @@ use wasm_bindgen_test::*;
 
 struct Keyed(u16);
 
-impl Render for Keyed {
-    fn render<'a>(&self, cx: &mut RenderContext<'a>) -> Node<'a> {
+impl<'a> Render<'a> for Keyed {
+    fn render(&self, cx: &mut RenderContext<'a>) -> Node<'a> {
         let key = bumpalo::format!(in cx.bump, "{}", self.0).into_bump_str();
         div(&cx)
             .attr("class", "keyed")
@@ -33,8 +33,8 @@ where
 
 async fn assert_keyed<Before, After>(before: Before, after: After) -> Result<(), JsValue>
 where
-    Before: 'static + Render,
-    After: 'static + Render,
+    Before: 'static + for<'a> Render<'a>,
+    After: 'static + for<'a> Render<'a>,
 {
     #[wasm_bindgen(module = "/tests/web/keyed.js")]
     extern "C" {

--- a/tests/web/main.rs
+++ b/tests/web/main.rs
@@ -50,7 +50,7 @@ pub fn init_logging() {
 
 /// Assert that the `container` contains the physical DOM tree that matches
 /// `r`'s rendered virtual DOM.
-pub fn assert_rendered<R: Render>(container: &web_sys::Element, r: &R) {
+pub fn assert_rendered<R: for<'a> Render<'a>>(container: &web_sys::Element, r: &R) {
     init_logging();
 
     let cached_set = &RefCell::new(CachedSet::default());
@@ -155,11 +155,11 @@ pub struct RenderFn<F>(F)
 where
     F: for<'a> Fn(&mut RenderContext<'a>) -> Node<'a>;
 
-impl<F> Render for RenderFn<F>
+impl<'a, F> Render<'a> for RenderFn<F>
 where
-    F: for<'a> Fn(&mut RenderContext<'a>) -> Node<'a>,
+    F: for<'b> Fn(&mut RenderContext<'b>) -> Node<'b>,
 {
-    fn render<'a>(&self, cx: &mut RenderContext<'a>) -> Node<'a> {
+    fn render(&self, cx: &mut RenderContext<'a>) -> Node<'a> {
         (self.0)(cx)
     }
 }
@@ -169,8 +169,8 @@ where
 /// the physical DOM tree correctly matches `after`.
 pub async fn assert_before_after<R, S>(before: R, after: S) -> Result<(), JsValue>
 where
-    R: 'static + Render,
-    S: 'static + Render,
+    R: 'static + for<'a> Render<'a>,
+    S: 'static + for<'a> Render<'a>,
 {
     let container = create_element("div");
 

--- a/tests/web/render.rs
+++ b/tests/web/render.rs
@@ -35,7 +35,7 @@ fn container_is_emptied_upon_drop() {
     assert!(container.first_child().is_none());
 }
 
-/// Originally, dodrio would use go through the className property for SVGs.
+/// Originally, dodrio would use the className property for SVGs.
 /// 
 /// This is problematic because when SVG elements are created, the className is flagged as a read
 /// only property, so setting it causes an exception to be thrown. Here's an example of how this


### PR DESCRIPTION
Changed the Render trait to be generic across a lifetime instead of containing a generic render function. This allows components that implement Render to contain bump-allocated fields as well, which can make it easier to separate the rendering logic without resorting to raw functions or duplicate allocations. More details in #46.

This also includes a fix for #125 that was already in my fork. I can revert it if we want to separate these two issues.